### PR TITLE
Refine update-chats > continuation fetch logic

### DIFF
--- a/backend/libs/infrastructure/service/youtubei/utils/FirstContinuationFetcher.ts
+++ b/backend/libs/infrastructure/service/youtubei/utils/FirstContinuationFetcher.ts
@@ -22,7 +22,7 @@ export class FirstContinuationFetcher {
   /**
    * continuation, INNERTUBE_API_KEYを取得
    */
-  async fetch(videoId: VideoId): Promise<Options> {
+  async fetch(videoId: VideoId): Promise<Options | undefined> {
     const res = await axios.get(this.chatUri, {
       headers: this.headers,
       params: { v: videoId.get() }
@@ -45,13 +45,6 @@ export class FirstContinuationFetcher {
           }
         : undefined
 
-    if (!ret)
-      throw new Error(
-        `Failed to fetch FirstContinuation: 
-          * Maybe the Live Stream is already ended. 
-          * Maybe the stream is member only.
-          * videoId: ${videoId.get()}`
-      )
     return ret
   }
 


### PR DESCRIPTION
   * continuationが保存されていても、1分以内に更新されていない場合は更新する
   * 古すぎるとどうやらエラーも出ず、単にレスポンスが０件になってしまい気づきにくいバグになる