### PR TITLE
Refine INSERT SupersRanking logic, Impl calcLast24HoursOne

### DIFF
--- a/backend/apps/closed-api-server/src/presentation/supers-rankings/dto/GetSupersRankingHistories.dto.ts
+++ b/backend/apps/closed-api-server/src/presentation/supers-rankings/dto/GetSupersRankingHistories.dto.ts
@@ -1,4 +1,5 @@
-import { IsIn, IsOptional, IsRFC3339, IsString } from 'class-validator'
+import { Type } from 'class-transformer'
+import { IsIn, IsInt, IsOptional, IsRFC3339, IsString } from 'class-validator'
 import { ChannelId } from '@domain'
 import { PeriodStrings, PeriodString, Period } from '@domain/lib/period'
 import {
@@ -25,6 +26,11 @@ export class GetSupersRankingHistories {
   @IsRFC3339()
   createdAfter?: string
 
+  @IsOptional()
+  @IsInt()
+  @Type(() => Number)
+  limit?: number
+
   toChannelId = () => new ChannelId(this.channelId)
 
   toPeriod = () => new Period(this.period)
@@ -38,4 +44,6 @@ export class GetSupersRankingHistories {
   toCreatedAfter = () => {
     return this.createdAfter ? new Date(this.createdAfter) : undefined
   }
+
+  toLimit = () => this.limit
 }

--- a/backend/apps/closed-api-server/src/presentation/supers-rankings/supers-rankings.controller.ts
+++ b/backend/apps/closed-api-server/src/presentation/supers-rankings/supers-rankings.controller.ts
@@ -47,7 +47,8 @@ export class SupersRankingsController {
         period: dto.toPeriod(),
         rankingType: dto.toRankingType(),
         createdAt: { gte: dto.toCreatedAfter(), lte: dto.toCreatedBefore() }
-      }
+      },
+      limit: dto.toLimit()
     })
   }
 }

--- a/backend/apps/closed-api-server/src/presentation/supers-rankings/supers-rankings.controller.ts
+++ b/backend/apps/closed-api-server/src/presentation/supers-rankings/supers-rankings.controller.ts
@@ -18,7 +18,8 @@ export class SupersRankingsController {
 
   /**
    * Retuen a latest ranking
-   * @returns 「単一の」SupersRanking
+   * @returns SupersRanking
+   * @returns NULL ランキング圏外。つまり配信していない、スパチャ額がゼロ、登録したばかりで集計前など
    *
    * IDが指定できないので便宜上複数取得のEndpointになっているが
    * 実際返却するのは「単一の」SupersRankingなので注意
@@ -34,7 +35,10 @@ export class SupersRankingsController {
     })
   }
 
-  /** Retuen histories of a channel */
+  /**
+   * Retuen histories of a channel
+   * @returns SupersRankings ランキング圏外の日はデータが歯抜けになるので留意
+   **/
   @Get('/histories')
   async getSupersRankingHistories(@Query() dto: GetSupersRankingHistories) {
     return await this.supersRankingsScenario.getSupersRankingHistories({

--- a/backend/apps/closed-api-server/src/presentation/supers-rankings/supers-rankings.controller.ts
+++ b/backend/apps/closed-api-server/src/presentation/supers-rankings/supers-rankings.controller.ts
@@ -22,7 +22,7 @@ export class SupersRankingsController {
    * @returns NULL ランキング圏外。つまり配信していない、スパチャ額がゼロ、登録したばかりで集計前など
    *
    * IDが指定できないので便宜上複数取得のEndpointになっているが
-   * 実際返却するのは「単一の」SupersRankingなので注意
+   * 実際返却するのは「単一の」SupersRanking || NULL である
    **/
   @Get()
   async getSupersRankings(@Query() dto: GetSupersRankings) {

--- a/backend/apps/closed-api-server/src/presentation/supers-rankings/supers-rankings.scenario.ts
+++ b/backend/apps/closed-api-server/src/presentation/supers-rankings/supers-rankings.scenario.ts
@@ -12,14 +12,25 @@ export class SupersRankingsScenario {
   }
 
   async getSupersRankings(
-    args: Parameters<SupersRankingsService['findOne']>[0]
+    args: Parameters<SupersRankingsService['findAggregatedOne']>[0]
   ) {
-    return await this.supersRankingsService.findOne(args)
+    if (args.where.period.isLast24Hours()) {
+      // last24Hours の場合は都度計算
+      return await this.supersRankingsService.calcLast24HoursOne(args)
+    } else {
+      // それ以外は集計テーブルから取得
+      return await this.supersRankingsService.findAggregatedOne(args)
+    }
   }
 
   async getSupersRankingHistories(
     args: Parameters<SupersRankingsService['findHistories']>[0]
   ) {
-    return await this.supersRankingsService.findHistories(args)
+    if (args.where.period.isLast24Hours()) {
+      // last24Hours の場合は都度計算
+    } else {
+      // それ以外は集計テーブルから取得
+      return await this.supersRankingsService.findHistories(args)
+    }
   }
 }

--- a/backend/libs/application/supers-rankings/supers-rankings.service.ts
+++ b/backend/libs/application/supers-rankings/supers-rankings.service.ts
@@ -12,8 +12,16 @@ export class SupersRankingsService {
     await this.supersRankingRepository.createMany(args)
   }
 
-  async findOne(args: Parameters<SupersRankingRepository['findOne']>[0]) {
-    return await this.supersRankingRepository.findOne(args)
+  async calcLast24HoursOne(
+    args: Parameters<SupersRankingRepository['calcLast24HoursOne']>[0]
+  ) {
+    return await this.supersRankingRepository.calcLast24HoursOne(args)
+  }
+
+  async findAggregatedOne(
+    args: Parameters<SupersRankingRepository['findAggregatedOne']>[0]
+  ) {
+    return await this.supersRankingRepository.findAggregatedOne(args)
   }
 
   async findHistories(

--- a/backend/libs/domain/supers-ranking/SupersRanking.repository.ts
+++ b/backend/libs/domain/supers-ranking/SupersRanking.repository.ts
@@ -19,8 +19,13 @@ export interface SupersRankingRepository {
     }
   }) => Promise<void>
 
+  /** 「過去24時間」の最新の順位を計算して取得 */
+  calcLast24HoursOne: (args: {
+    where: { channelId: ChannelId; rankingType: RankingType }
+  }) => Promise<SupersRanking | null>
+
   /** チャンネルの最新の順位を取得 */
-  findOne: (args: {
+  findAggregatedOne: (args: {
     where: { channelId: ChannelId; period: Period; rankingType: RankingType }
   }) => Promise<SupersRanking | null>
 
@@ -32,5 +37,6 @@ export interface SupersRankingRepository {
       rankingType: RankingType
       createdAt: { gte?: Date; lte?: Date }
     }
+    limit?: number
   }) => Promise<SupersRankings>
 }

--- a/backend/libs/domain/supers-ranking/SupersRanking.repository.ts
+++ b/backend/libs/domain/supers-ranking/SupersRanking.repository.ts
@@ -7,7 +7,11 @@ import {
 import { ChannelId } from '@domain/youtube'
 
 export interface SupersRankingRepository {
-  /** 指定した期間x切り口の順位表を算出し、全チャンネル一気にINSERTする */
+  /**
+   * 指定した期間x切り口の順位表を算出し、全チャンネル一気にINSERTする
+   * summary."${period}" > 0 のもののみ順位を割り当てる。
+   * 0の場合はそもそもINSERTしない（＝ランキング圏外）
+   **/
   createMany: (args: {
     data: {
       period: Period

--- a/backend/libs/infrastructure/supers-ranking/SupersRanking.repository-impl.ts
+++ b/backend/libs/infrastructure/supers-ranking/SupersRanking.repository-impl.ts
@@ -42,6 +42,7 @@ export class SupersRankingRepositoryImpl implements SupersRankingRepository {
           ${rankOver} AS rank
         FROM "YoutubeStreamSupersSummaryLatest" summary
         JOIN "Channel" c ON summary."channelId" = c."id"
+        WHERE summary."${period.get()}" > 0
       )
       SELECT "channelId", '${period.get()}', '${rankingType.get()}', rank, NOW()
       FROM x;


### PR DESCRIPTION
## Refine INSERT SupersRanking logic

スパチャ額がゼロの場合は「ランキング圏外」として
そもそもレコードをINSERTしない、取得してもNULLになるようにした。

## Impl calcLast24HoursOne

過去24時間のランキング順位を取得するロジックを実装した。
過去24時間は都度計算するので集計テーブルは使わない