### PR TITLE
prefetch=false for BottomNav, RankingTableRow, LinkToRanking

### DIFF
--- a/web/apis/youtube/getSupersRankingHistories.ts
+++ b/web/apis/youtube/getSupersRankingHistories.ts
@@ -2,7 +2,7 @@ import {
   SupersRankingHistoriesSchema,
   responseHistoriesSchema
 } from 'apis/youtube/schema/supersRankingSchema'
-import { CACHE_10M, fetchAPI } from 'lib/fetchAPI'
+import { CACHE_10M, CACHE_12H, fetchAPI } from 'lib/fetchAPI'
 import { Period } from 'types/period'
 import { RankingType } from 'types/supers-ranking'
 
@@ -36,9 +36,16 @@ export async function getSupersRankingHistories({
     ...(limit !== undefined && { limit: String(limit) })
   })
 
+  // last24Hoursの場合は古い値が見えることが多いのでキャッシュしない
+  // （バックエンドのControllerでキャッシュしている）
+  const cache: RequestInit =
+    period === 'last24Hours'
+      ? { cache: 'no-store' }
+      : { next: { revalidate: CACHE_12H } }
+
   const res = await fetchAPI(
     `/api/supers-rankings/histories?${searchParams.toString()}`,
-    { next: { revalidate: CACHE_10M } }
+    cache
   )
 
   if (!res.ok) {

--- a/web/apis/youtube/getSupersRankings.ts
+++ b/web/apis/youtube/getSupersRankings.ts
@@ -2,7 +2,7 @@ import {
   responseSchema,
   SupersRankingSchema
 } from 'apis/youtube/schema/supersRankingSchema'
-import { fetchAPI } from 'lib/fetchAPI'
+import { CACHE_12H, fetchAPI } from 'lib/fetchAPI'
 import { Period } from 'types/period'
 import { RankingType } from 'types/supers-ranking'
 
@@ -25,12 +25,14 @@ export async function getSupersRankings({
 
   // last24Hoursの場合は古い値が見えることが多いのでキャッシュしない
   // （バックエンドのControllerでキャッシュしている）
-  const noCache: RequestInit | undefined =
-    period === 'last24Hours' ? { cache: 'no-store' } : undefined
+  const cache: RequestInit =
+    period === 'last24Hours'
+      ? { cache: 'no-store' }
+      : { next: { revalidate: CACHE_12H } }
 
   const res = await fetchAPI(
     `/api/supers-rankings?${searchParams.toString()}`,
-    noCache
+    cache
   )
 
   if (!res.ok) {

--- a/web/components/bottom-navigation/BottomNavigation.tsx
+++ b/web/components/bottom-navigation/BottomNavigation.tsx
@@ -69,7 +69,7 @@ export default function BottomNavigation({ className }: Props) {
                   'bg-accent text-accent-foreground font-bold'
               )}
             >
-              <Link href={item.pathname + (item.query || '')} prefetch={true}>
+              <Link href={item.pathname + (item.query || '')} prefetch={false}>
                 <Icon className={`size-5`} />
                 <span className="text-xs">{item.label}</span>
               </Link>

--- a/web/features/channel/components/local-navigation/LocalNavigationForChannelsIdPages.tsx
+++ b/web/features/channel/components/local-navigation/LocalNavigationForChannelsIdPages.tsx
@@ -24,28 +24,23 @@ export default function LocalNavigationForChannelsIdPages({
         { name: t('overview.nav'), href: basePath, prefetch: true },
         {
           name: t('superChat.nav'),
-          href: `${basePath}/super-chat`,
-          prefetch: true
+          href: `${basePath}/super-chat`
         },
         {
           name: t('live.nav'),
-          href: [`${basePath}/live`, `${basePath}/asmr`],
-          prefetch: true
+          href: [`${basePath}/live`, `${basePath}/asmr`]
         },
         {
           name: t('concurrentViewers.nav'),
-          href: `${basePath}/concurrent-viewers`,
-          prefetch: true
+          href: `${basePath}/concurrent-viewers`
         },
         {
           name: t('comments.nav'),
-          href: [`${basePath}/comments`],
-          prefetch: true
+          href: [`${basePath}/comments`]
         },
         {
           name: t('streamTimes.nav'),
-          href: `${basePath}/stream-times`,
-          prefetch: true
+          href: `${basePath}/stream-times`
         },
         hasFAQ(channelId)
           ? {

--- a/web/features/channel/components/super-chat/link/LinkToRanking.tsx
+++ b/web/features/channel/components/super-chat/link/LinkToRanking.tsx
@@ -32,7 +32,7 @@ export default function LinkToRanking({
   return (
     <Link
       href={`/youtube/channels/ranking?${searchParams.toString()}`}
-      prefetch={true}
+      prefetch={false}
       onClick={() => {
         if (channelId) {
           sessionStorage.setItem(RANK_HIGHLIGHTER_STORAGE_KEY, channelId)

--- a/web/features/channels-ranking/components/table/ChannelsRankingTable.tsx
+++ b/web/features/channels-ranking/components/table/ChannelsRankingTable.tsx
@@ -89,7 +89,7 @@ export default async function ChannelsRankingTable({
             summary => summary.channelId === channelId
           )?.[period] as bigint | undefined
 
-          /** Top 5まではCTRが高いのでprefetch=true */
+          /** prefetch=false */
           const LinkCell = (
             props: PropsWithChildren &
               Omit<
@@ -100,7 +100,7 @@ export default async function ChannelsRankingTable({
             <LinkToChannelCell
               channelId={channelId}
               group={channel.peakX.group}
-              prefetch={i < 5}
+              prefetch={false} // before: i < 5
               {...props}
             />
           )

--- a/web/features/stream-ranking/components/table/StreamRankingTable.tsx
+++ b/web/features/stream-ranking/components/table/StreamRankingTable.tsx
@@ -75,7 +75,7 @@ export default async function StreamRankingTable({
             <LinkToChannelCell
               channelId={channelId}
               group={channel.peakX.group}
-              prefetch={i < 5}
+              prefetch={false} // before: i < 5
               {...props}
             />
           )


### PR DESCRIPTION
- Removing explicit prefetch attributes from navigation links.
- Updating caching logic in getSupersRankings.ts and getSupersRankingHistories.ts to use CACHE_12H for non-"last24Hours" requests.