### PR TITLE
:rocket: Add canonical for top page in liveId context

### DIFF
--- a/web/app/[locale]/(end-user)/(no-layout)/youtube/live/[videoId]/_components/page/LiveIdBasePage.tsx
+++ b/web/app/[locale]/(end-user)/(no-layout)/youtube/live/[videoId]/_components/page/LiveIdBasePage.tsx
@@ -31,7 +31,8 @@ export async function generateBaseMetadata(
   const { locale, videoId } = await props.params
   const {
     metrics: { peakConcurrentViewers },
-    snippet: { title, channelId }
+    snippet: { title, channelId },
+    membersOnly
   } = await getStream(videoId)
 
   const [t, { basicInfo }, bundle, superChats] = await Promise.all([
@@ -57,7 +58,9 @@ export async function generateBaseMetadata(
       ? title.slice(0, TITLE_MAX_LENGTH - 1) + '…'
       : title
 
-  const comment = superChats.map(s => s.userComment).join(', ')
+  const comment = membersOnly
+    ? t('commentForMembersOnly')
+    : superChats.map(s => s.userComment).join(', ')
 
   return {
     title: `${t('title', { title: slicedTitle, channel: basicInfo.title })}`,

--- a/web/app/[locale]/(end-user)/(no-layout)/youtube/live/[videoId]/_components/page/LiveIdBasePage.tsx
+++ b/web/app/[locale]/(end-user)/(no-layout)/youtube/live/[videoId]/_components/page/LiveIdBasePage.tsx
@@ -4,11 +4,15 @@ import { Locale } from 'next-intl'
 import { setRequestLocale, getTranslations } from 'next-intl/server'
 import { getChannel } from 'apis/youtube/getChannel'
 import { getStream } from 'apis/youtube/getStream'
+import { getSuperChats } from 'apis/youtube/getSuperChats'
+import { getSupersBundle } from 'apis/youtube/getSupersBundle'
 import { StreamSchema } from 'apis/youtube/schema/streamSchema'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import TheaterLayout from 'components/layouts/TheaterLayout'
 import AutoRouterRefresh from 'components/router/AutoRouterRefresh'
 import { setGroup } from 'lib/server-only-context/cache'
+import { formatMicrosAsRoundedAmount } from 'utils/amount'
+import { getWebUrl } from 'utils/web-url'
 import LayoutFactory from '../layouts/LayoutFactory'
 import DefaultModeTemplate from '../template/DefaultModeTemplate'
 import TheaterModeTemplate from '../template/TheaterModeTemplate'
@@ -22,39 +26,49 @@ export type LiveIdBasePageProps = {
 type Props = LiveIdBasePageProps
 
 export async function generateBaseMetadata(
-  props: Props & {
-    namespace:
-      | 'Page.youtube.live.id.index.metadata'
-      | 'Page.youtube.live.id.earnings.metadata'
-      | 'Page.youtube.live.id.superChat.comments.metadata'
-      | 'Page.youtube.live.id.comments.metadata'
-      | 'Page.youtube.live.id.concurrentViewers.metadata'
-  }
+  props: Props & { namespace: 'Page.youtube.live.id.index.metadata' }
 ): Promise<Metadata> {
   const { locale, videoId } = await props.params
-  const t = await getTranslations({
-    locale,
-    namespace: props.namespace
-  })
   const {
+    metrics: { peakConcurrentViewers },
     snippet: { title, channelId }
   } = await getStream(videoId)
-  const { basicInfo } = await getChannel(channelId)
+
+  const [t, { basicInfo }, bundle, superChats] = await Promise.all([
+    getTranslations({
+      locale,
+      namespace: props.namespace
+    }),
+    getChannel(channelId),
+    getSupersBundle(videoId),
+    getSuperChats({
+      videoId,
+      userCommentNotNull: true,
+      orderBy: [
+        { field: 'amountMicros', order: 'desc' },
+        { field: 'createdAt', order: 'desc' }
+      ],
+      limit: 2
+    })
+  ])
 
   const slicedTitle =
     title.length > TITLE_MAX_LENGTH
       ? title.slice(0, TITLE_MAX_LENGTH - 1) + '…'
       : title
 
+  const comment = superChats.map(s => s.userComment).join(', ')
+
   return {
-    title: `${t('title', {
-      title: slicedTitle,
-      channel: basicInfo.title
-    })}`,
+    title: `${t('title', { title: slicedTitle, channel: basicInfo.title })}`,
     description: `${t('description', {
-      title: slicedTitle,
-      channel: basicInfo.title
-    })}`
+      superChat: formatMicrosAsRoundedAmount(bundle?.amountMicros ?? BigInt(0)),
+      concurrentViewers: peakConcurrentViewers.toLocaleString(),
+      comment: comment
+    })}`,
+    alternates: {
+      canonical: `${getWebUrl()}/${locale}/youtube/live/${videoId}`
+    }
   }
 }
 

--- a/web/app/[locale]/(end-user)/(no-layout)/youtube/live/[videoId]/comments/page.tsx
+++ b/web/app/[locale]/(end-user)/(no-layout)/youtube/live/[videoId]/comments/page.tsx
@@ -12,7 +12,7 @@ type Props = LiveIdBasePageProps
 export async function generateMetadata(props: Props): Promise<Metadata> {
   return generateBaseMetadata({
     ...props,
-    namespace: 'Page.youtube.live.id.comments.metadata'
+    namespace: 'Page.youtube.live.id.index.metadata'
   })
 }
 

--- a/web/app/[locale]/(end-user)/(no-layout)/youtube/live/[videoId]/concurrent-viewers/page.tsx
+++ b/web/app/[locale]/(end-user)/(no-layout)/youtube/live/[videoId]/concurrent-viewers/page.tsx
@@ -10,7 +10,7 @@ type Props = LiveIdBasePageProps
 export async function generateMetadata(props: Props): Promise<Metadata> {
   return generateBaseMetadata({
     ...props,
-    namespace: 'Page.youtube.live.id.concurrentViewers.metadata'
+    namespace: 'Page.youtube.live.id.index.metadata'
   })
 }
 

--- a/web/app/[locale]/(end-user)/(no-layout)/youtube/live/[videoId]/earnings/page.tsx
+++ b/web/app/[locale]/(end-user)/(no-layout)/youtube/live/[videoId]/earnings/page.tsx
@@ -10,7 +10,7 @@ type Props = LiveIdBasePageProps
 export async function generateMetadata(props: Props): Promise<Metadata> {
   return generateBaseMetadata({
     ...props,
-    namespace: 'Page.youtube.live.id.earnings.metadata'
+    namespace: 'Page.youtube.live.id.index.metadata'
   })
 }
 

--- a/web/app/[locale]/(end-user)/(no-layout)/youtube/live/[videoId]/page.tsx
+++ b/web/app/[locale]/(end-user)/(no-layout)/youtube/live/[videoId]/page.tsx
@@ -8,7 +8,7 @@ import { LiveIdTemplate } from './_components/template/LiveIdTemplate'
 type Props = LiveIdBasePageProps
 
 export async function generateMetadata(props: Props): Promise<Metadata> {
-  return generateBaseMetadata({
+  return await generateBaseMetadata({
     ...props,
     namespace: 'Page.youtube.live.id.index.metadata'
   })

--- a/web/app/[locale]/(end-user)/(no-layout)/youtube/live/[videoId]/super-chat/comments/page.tsx
+++ b/web/app/[locale]/(end-user)/(no-layout)/youtube/live/[videoId]/super-chat/comments/page.tsx
@@ -12,7 +12,7 @@ type Props = LiveIdBasePageProps
 export async function generateMetadata(props: Props): Promise<Metadata> {
   return generateBaseMetadata({
     ...props,
-    namespace: 'Page.youtube.live.id.superChat.comments.metadata'
+    namespace: 'Page.youtube.live.id.index.metadata'
   })
 }
 

--- a/web/config/i18n/messages/en.json
+++ b/web/config/i18n/messages/en.json
@@ -236,7 +236,8 @@
           "index": {
             "metadata": {
               "title": "{channel} {title} - Stats",
-              "description": "Super Chat: {superChat} Yen, Concurrent Viewers: {concurrentViewers}. {comment}"
+              "description": "Super Chat: {superChat} Yen, Concurrent Viewers: {concurrentViewers}. {comment}",
+              "commentForMembersOnly": "Member-only live stream, no data available"
             }
           },
           "button": {

--- a/web/config/i18n/messages/en.json
+++ b/web/config/i18n/messages/en.json
@@ -235,34 +235,8 @@
         "id": {
           "index": {
             "metadata": {
-              "title": "{channel} {title} - Live Stats",
-              "description": "Watch YouTube Live! Check {channel}'s Super Chat amount and concurrent viewers. PeakX even publishes all Super Chat comments!"
-            }
-          },
-          "earnings": {
-            "metadata": {
-              "title": "{channel} {title} - Super Chat",
-              "description": "Check the Super Chat amount for this live stream! Don't miss out on the popular moments of {channel}."
-            }
-          },
-          "superChat": {
-            "comments": {
-              "metadata": {
-                "title": "{channel} {title} - Super Chat Comments",
-                "description": "Check the Super Chat Comments for this live stream! Don't miss out on the popular moments of {channel}."
-              }
-            }
-          },
-          "comments": {
-            "metadata": {
-              "title": "{channel} {title} - Comments",
-              "description": "Check out user comments on this live stream! Don't miss out on the popular moments on {channel}."
-            }
-          },
-          "concurrentViewers": {
-            "metadata": {
-              "title": "{channel} {title} - Concurrent Viewers",
-              "description": "Check the number of concurrent viewers for {channel}'s {title}."
+              "title": "{channel} {title} - Stats",
+              "description": "Super Chat: {superChat} Yen, Concurrent Viewers: {concurrentViewers}. {comment}"
             }
           },
           "button": {

--- a/web/config/i18n/messages/ja.json
+++ b/web/config/i18n/messages/ja.json
@@ -235,34 +235,8 @@
         "id": {
           "index": {
             "metadata": {
-              "title": "{channel} {title} - ライブ概要",
-              "description": "YouTubeライブを視聴！{channel}のスパチャ金額や同接数をチェックし人気の瞬間を見逃さず確認しよう。PeakXではなんとスパチャコメントもすべて掲載！"
-            }
-          },
-          "earnings": {
-            "metadata": {
-              "title": "{channel} {title}のスパチャ金額",
-              "description": "このライブ配信のスパチャ金額をチェック！{channel}の人気の瞬間を見逃さず確認しよう。VTuberファン必見の情報をお届けします。"
-            }
-          },
-          "superChat": {
-            "comments": {
-              "metadata": {
-                "title": "{channel} {title}のスパチャコメント",
-                "description": "このライブ配信のスパチャコメントをチェック！{channel}の人気の瞬間を見逃さず確認しよう。VTuberファン必見の情報をお届けします。"
-              }
-            }
-          },
-          "comments": {
-            "metadata": {
-              "title": "{channel} {title}のコメント",
-              "description": "このライブ配信のユーザーコメントをチェック！{channel}の人気の瞬間を見逃さず確認しよう。VTuberファン必見の情報をお届けします。"
-            }
-          },
-          "concurrentViewers": {
-            "metadata": {
-              "title": "{channel} {title}の同接数",
-              "description": "このライブ配信の同接数をチェック！{channel} {title}"
+              "title": "{channel} {title} - ライブ分析",
+              "description": "スパチャ{superChat}円、同接数{concurrentViewers}人。{comment}"
             }
           },
           "button": {

--- a/web/config/i18n/messages/ja.json
+++ b/web/config/i18n/messages/ja.json
@@ -236,7 +236,8 @@
           "index": {
             "metadata": {
               "title": "{channel} {title} - ライブ分析",
-              "description": "スパチャ{superChat}円、同接数{concurrentViewers}人。{comment}"
+              "description": "スパチャ{superChat}円、同接数{concurrentViewers}人。{comment}",
+              "commentForMembersOnly": "メンバー限定ライブ配信のためデータがありません"
             }
           },
           "button": {


### PR DESCRIPTION
- 自己参照canonicalを追加
- earnings, commentsなどサブページにもトップへのcanonicalを付与