### PR TITLE
fix: VideoAPISchema の thumbnails スキーマを修正して scheduled 配信が更新されない問題を解決

### DIFF
--- a/backend/libs/infrastructure/service/youtube-data-api/lib/VideoAPISchema.ts
+++ b/backend/libs/infrastructure/service/youtube-data-api/lib/VideoAPISchema.ts
@@ -7,14 +7,43 @@ export const videoAPISchema = z.object({
     publishedAt: z.string().datetime(),
     channelId: z.string(),
     title: z.string(),
-    thumbnails: z.record(
-      z.enum(['default', 'medium', 'high', 'standard', 'maxres']),
-      z.object({
-        url: z.string(),
-        width: z.number().optional(),
-        height: z.number().optional()
-      })
-    ),
+    thumbnails: z.object({
+      default: z
+        .object({
+          url: z.string(),
+          width: z.number().optional(),
+          height: z.number().optional()
+        })
+        .optional(),
+      medium: z
+        .object({
+          url: z.string(),
+          width: z.number().optional(),
+          height: z.number().optional()
+        })
+        .optional(),
+      high: z
+        .object({
+          url: z.string(),
+          width: z.number().optional(),
+          height: z.number().optional()
+        })
+        .optional(),
+      standard: z
+        .object({
+          url: z.string(),
+          width: z.number().optional(),
+          height: z.number().optional()
+        })
+        .optional(),
+      maxres: z
+        .object({
+          url: z.string(),
+          width: z.number().optional(),
+          height: z.number().optional()
+        })
+        .optional()
+    }),
     tags: z.array(z.string()).optional(),
     categoryId: z.string(),
     defaultLanguage: z.string().optional()


### PR DESCRIPTION
## Summary

- YouTube API の `thumbnails` スキーマが厳格すぎて、一部の動画がバリデーションエラーで除外されていた問題を修正
- これにより `scheduled` 配信が `live` / `ended` に更新されず、古い配信が `scheduled` のまま残り続けていた

## 問題の調査経緯

### 1. 問題の発見
- `status=scheduled` のYouTubeライブ配信のうち、実際には配信終了済みのものが `scheduled` のまま残っていた
- 最も古いものは32日前（2025-11-14）の配信

### 2. 初期調査
- YouTube API を直接呼び出すと、問題の配信には `actualStartTime` と `actualEndTime` が正常に存在
- DB の `updatedAt` が配信開始前のまま → **バッチが処理していない**ことを確認

### 3. バッチ実行ログの確認
- `handleScheduled/chunk:` のログは出力されている → バッチは実行されている
- `start the stream:` のログは出ていない → `startLives` の処理が実行されていない
- `VideoTranslator: IP0yn1Id7uA [` という **Zod パースエラー**のログが継続的に出力されていた

### 4. 根本原因の特定
ローカルで Zod バリデーションをテストした結果、以下のエラーが判明：

```
videoId: IP0yn1Id7uA
  [ERROR] バリデーション失敗:
  1. path: snippet.thumbnails.standard
     code: invalid_type
     message: Invalid input: expected object, received undefined
  2. path: snippet.thumbnails.maxres
     code: invalid_type
     message: Invalid input: expected object, received undefined
```

**原因**: `z.record()` を使った `thumbnails` スキーマが、存在しないキーに対してバリデーションエラーを発生させていた

YouTube API は必ずしもすべてのサムネイルサイズ (`default`, `medium`, `high`, `standard`, `maxres`) を返すわけではない。

### 5. 影響範囲
- Zod バリデーションに失敗した動画は `undefined` として扱われ、**すべての処理から除外**されていた
- PubSubHubBub の `handleUpdatedCallback` でも同様に `hUC video not found:` エラーが発生

## 修正内容

`VideoAPISchema.ts` の `thumbnails` スキーマを修正：

**Before:**
```typescript
thumbnails: z.record(
  z.enum(['default', 'medium', 'high', 'standard', 'maxres']),
  z.object({ url, width, height })
),
```

**After:**
```typescript
thumbnails: z.object({
  default: z.object({ url, width, height }).optional(),
  medium: z.object({ url, width, height }).optional(),
  high: z.object({ url, width, height }).optional(),
  standard: z.object({ url, width, height }).optional(),
  maxres: z.object({ url, width, height }).optional()
}),
```

## Test plan

- [x] 型チェック (`npm run type-check`) 成功
- [x] Lint (`npm run lint`) 成功
- [x] テスト (`npm test`) 成功
- [x] ローカルで Zod バリデーションが成功することを確認
- [ ] デプロイ後、`update-streams` バッチで `scheduled` 配信が正しく更新されることを確認
- [ ] Cloud Logging で `VideoTranslator:` エラーが出なくなることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)