### PR TITLE
fix: vitest の test:watch が concurrently で動作するよう修正

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -13,7 +13,7 @@
     "prisma:dev": "prisma migrate dev --schema prisma/schema",
     "prisma:deploy": "prisma migrate deploy --schema prisma/schema",
     "test": "vitest run",
-    "test:watch": "vitest",
+    "test:watch": "vitest --watch",
     "test:e2e": "vitest run --config vitest.e2e.config.ts",
     "test:coverage": "vitest run --coverage",
     "app": "zx ./scripts/standalone-apps/factory.mjs"

--- a/scripts/concurrently/main.ts
+++ b/scripts/concurrently/main.ts
@@ -11,7 +11,6 @@ concurrently(
       name: 'be  ',
       cwd: path.resolve(rootDir, 'backend')
     },
-
     {
       command: `npm run test:watch`,
       name: 'be:u',
@@ -33,7 +32,7 @@ concurrently(
   ],
   {
     prefix: '{name}',
-    killOthers: ['failure'],
+    killOthersOn: ['failure'],
     prefixColors: [
       'bold.bgMagenta',
       'bold.bgCyan',

--- a/web/package.json
+++ b/web/package.json
@@ -9,7 +9,7 @@
     "build": "next build",
     "start": "next start",
     "test": "vitest run",
-    "test:watch": "vitest",
+    "test:watch": "vitest --watch",
     "test:coverage": "vitest run --coverage",
     "test:type-check": "npm run type-check:test && npm run test"
   },


### PR DESCRIPTION
## Summary
- `vitest` コマンドに `--watch` フラグを明示的に追加
- concurrently 経由（TTY なし環境）でもウォッチモードが動作するよう修正
- backend/web 両方の `test:watch` スクリプトを更新

## Test plan
- [ ] `npm run conc` を実行し、`we:t` と `be:u` がウォッチモードで動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)