### PR TITLE
refactor: メールドメインとブランド名を peakx.net から vcharts.net に変更

### DIFF
--- a/react-email-starter/emails/welcome-mail-v0.tsx
+++ b/react-email-starter/emails/welcome-mail-v0.tsx
@@ -76,7 +76,7 @@ export const WelcomeEmail = ({
               © 2025 VCharts, Inc. All rights reserved.
             </Text>
             {/* <Text style={footer}>〒100-0001 東京都千代田区1-1-1</Text> */}
-            <Text style={footer}>support@peakx.net</Text>
+            <Text style={footer}>support@vcharts.net</Text>
             <Text style={footer}>
               <Link
                 href="https://www.vcharts.net/ja/terms-of-use-and-privacy-policy"

--- a/web/app/[locale]/(end-user)/(default)/channels/add/_components/form/RegistrationForm.tsx
+++ b/web/app/[locale]/(end-user)/(default)/channels/add/_components/form/RegistrationForm.tsx
@@ -57,7 +57,7 @@ export function RegistrationForm({ groups }: RegistrationFormProps) {
     }
     if (isRegistered) {
       return (
-        <ErrorMessage message="このチャンネルはすでにPeakXに登録されています。登録後1週間程度でライブの取得が始まります" />
+        <ErrorMessage message="このチャンネルはすでに登録されています。登録後1週間程度でライブの取得が始まります" />
       )
     }
     if (isAlreadyApproved) {

--- a/web/app/[locale]/(end-user)/(default)/groups/add/_components/GroupRegistrationHistory.tsx
+++ b/web/app/[locale]/(end-user)/(default)/groups/add/_components/GroupRegistrationHistory.tsx
@@ -128,7 +128,7 @@ export function GroupRegistrationHistory() {
       <CardHeader>
         <CardTitle>{t('title')}</CardTitle>
         <CardDescription>
-          ステータス『完了』になると１週間程度でUI上に表示されます
+          ステータス『承認済み』になると１週間程度でUI上に表示されます
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-3">

--- a/web/app/[locale]/(end-user)/(default)/legal/tokushoho/components/LegalInformation.tsx
+++ b/web/app/[locale]/(end-user)/(default)/legal/tokushoho/components/LegalInformation.tsx
@@ -9,7 +9,7 @@ export function LegalInformation() {
         <div className="space-y-4">
           <Item useGrid>
             <div className="font-medium">販売事業者名</div>
-            <div className="md:col-span-2">山本晃大（PeakX運営）</div>
+            <div className="md:col-span-2">山本晃大（VCharts運営）</div>
           </Item>
           <Item useGrid>
             <div className="font-medium">所在地</div>
@@ -24,8 +24,8 @@ export function LegalInformation() {
           <Item useGrid>
             <div className="font-medium">お問合せ先</div>
             <div className="md:col-span-2">
-              <a href="mailto:support@peakx.net" className="underline">
-                support@peakx.net
+              <a href="mailto:support@vcharts.net" className="underline">
+                support@vcharts.net
               </a>
             </div>
           </Item>

--- a/web/components/emails/welcome-mail.tsx
+++ b/web/components/emails/welcome-mail.tsx
@@ -72,7 +72,7 @@ export const WelcomeEmail = ({ username, userEmail }: WelcomeEmailProps) => {
               © 2025 VCharts, Inc. All rights reserved.
             </Text>
             {/* <Text style={footer}>〒100-0001 東京都千代田区1-1-1</Text> */}
-            <Text style={footer}>support@peakx.net</Text>
+            <Text style={footer}>support@vcharts.net</Text>
             <Text style={footer}>
               <Link
                 href="https://www.vcharts.net/ja/terms-of-use-and-privacy-policy"

--- a/web/components/pwa/serverActions.ts
+++ b/web/components/pwa/serverActions.ts
@@ -3,7 +3,7 @@
 import webpush, { type PushSubscription } from 'web-push'
 
 webpush.setVapidDetails(
-  '<mailto:support@peakx.net>',
+  '<mailto:support@vcharts.net>',
   process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY!,
   process.env.VAPID_PRIVATE_KEY!
 )

--- a/web/lib/auth/authProviders.ts
+++ b/web/lib/auth/authProviders.ts
@@ -5,7 +5,7 @@ import Resend from 'next-auth/providers/resend'
 
 const providers: Provider[] = [
   Google,
-  Resend({ from: 'PeakX.net <verify@peakx.net>' })
+  Resend({ from: 'VCharts.net <verify@vcharts.net>' })
 ]
 
 if (process.env.NODE_ENV === 'development') {

--- a/web/lib/auth/onSignUp.ts
+++ b/web/lib/auth/onSignUp.ts
@@ -23,7 +23,7 @@ export const onSignUp = async (pool: Pool, user: User) => {
 
     email &&
       resend.emails.send({
-        from: 'PeakX.net <noreply@peakx.net>',
+        from: 'VCharts.net <noreply@vcharts.net>',
         to: [email],
         subject: 'VChartsへようこそ！',
         react: WelcomeEmail({ username: name, userEmail: email })


### PR DESCRIPTION
## Summary
- メール送信ドメインを `peakx.net` → `vcharts.net` に変更
- 送信者名を `PeakX.net` → `VCharts.net` に変更
- 特商法ページの運営者名を「VCharts運営」に変更
- ユーザー向けメッセージから PeakX の文言を削除

## 変更ファイル
- `web/lib/auth/authProviders.ts` - 認証メール送信者
- `web/lib/auth/onSignUp.ts` - ウェルカムメール送信者
- `web/components/emails/welcome-mail.tsx` - メールフッターのサポートアドレス
- `react-email-starter/emails/welcome-mail-v0.tsx` - 同上
- `web/components/pwa/serverActions.ts` - VAPID連絡先
- `web/app/.../legal/tokushoho/components/LegalInformation.tsx` - 特商法ページ
- `web/app/.../channels/add/_components/form/RegistrationForm.tsx` - 登録フォーム

## Test plan
- [ ] 認証メールの送信者名が VCharts.net になっていることを確認
- [ ] ウェルカムメールの送信者名とフッターが正しいことを確認
- [ ] 特商法ページの表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)