### PR TITLE
fix: フィルター変更時にSuspenseのfallbackが表示されるよう修正

### DIFF
--- a/web/app/[locale]/(end-user)/(default)/_components/IndexTemplate.tsx
+++ b/web/app/[locale]/(end-user)/(default)/_components/IndexTemplate.tsx
@@ -57,7 +57,10 @@ export async function IndexTemplate({ days = DEFAULT_DAYS, group }: Props) {
 
         <FlexSection className="gap-6">
           <div className="flex-1 w-full">
-            <Suspense fallback={<StreamVolumeTrendSkeleton />}>
+            <Suspense
+              key={`${days}-${group}`}
+              fallback={<StreamVolumeTrendSkeleton />}
+            >
               <StreamVolumeTrendContainer days={days} group={group} />
             </Suspense>
           </div>


### PR DESCRIPTION
## Summary
- Suspenseにkey propを追加し、フィルター（days/group）変更時にスケルトン表示されるよう修正
- Next.js App RouterのSoft Navigation時にSuspense boundaryが再トリガーされない問題への対応

## Test plan
- [x] トップページでDaysセレクター（7日/28日/90日）を変更し、スケルトンが表示されることを確認
- [x] グループセレクターを変更し、スケルトンが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)