### PR TITLE
fix: breadcrumbが空配列の場合にも非表示にする

### DIFF
--- a/web/components/page/Page.tsx
+++ b/web/components/page/Page.tsx
@@ -48,9 +48,9 @@ export function Page({
         </div>
       )} */}
 
-      {!ads && breadcrumb && (
+      {!ads && breadcrumb?.length ? (
         <GlobalBreadcrumb items={breadcrumb} className="mb-4" />
-      )}
+      ) : null}
 
       {h1 && (
         <div


### PR DESCRIPTION
## Summary
- breadcrumbがnull/undefinedだけでなく空配列の場合も非表示にするよう修正

## Test plan
- [ ] breadcrumbが空配列のページでGlobalBreadcrumbが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)