### PR TITLE
style: チャートの配色を調整

### DIFF
--- a/web/app/[locale]/(end-user)/(no-layout)/youtube/live/[videoId]/earnings/_components/LiveIdEarningsTemplate.tsx
+++ b/web/app/[locale]/(end-user)/(no-layout)/youtube/live/[videoId]/earnings/_components/LiveIdEarningsTemplate.tsx
@@ -50,11 +50,11 @@ async function Earnings({ videoId }: { videoId: string }) {
   const chartConfig = {
     amount: {
       label: feat('chart.superChat.amount'),
-      color: 'var(--chart-1)'
+      color: 'var(--chart-3)'
     },
     cumulativeAmount: {
       label: feat('chart.superChat.cumulativeAmount'),
-      color: 'var(--chart-2)'
+      color: 'var(--chart-1)'
     }
   } satisfies ChartConfig
 

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -148,11 +148,11 @@
     --ring: hsl(41 88.7% 45.3%);
     --radius: 0.45rem;
 
-    --chart-1: hsl(12 76% 61%);
+    --chart-1: hsl(220 70% 50%);
     --chart-2: hsl(173 58% 39%);
-    --chart-3: hsl(197 37% 24%);
-    --chart-4: hsl(43 74% 66%);
-    --chart-5: hsl(27 87% 67%);
+    --chart-3: hsl(30 80% 55%);
+    --chart-4: hsl(280 65% 60%);
+    --chart-5: hsl(7, 60%, 46%);
 
     --gold: hsl(51 100% 45%);
     --silver: hsl(0 0% 40%);
@@ -192,7 +192,7 @@
     --chart-2: hsl(160 60% 45%);
     --chart-3: hsl(30 80% 55%);
     --chart-4: hsl(280 65% 60%);
-    --chart-5: hsl(340 75% 55%);
+    --chart-5: hsl(7, 60%, 46%);
 
     --gold: hsl(51 100% 45%);
     --silver: hsl(0 0% 85%);

--- a/web/features/channel/components/concurrent-viewers/bar-chart/concurrent-viewers/ConcurrentViewersBarChart.tsx
+++ b/web/features/channel/components/concurrent-viewers/bar-chart/concurrent-viewers/ConcurrentViewersBarChart.tsx
@@ -8,7 +8,7 @@ import Chart from './Chart'
 const chartConfig = {
   desktop: {
     label: 'Desktop',
-    color: 'var(--chart-1)'
+    color: 'var(--chart-3)'
   }
 } satisfies ChartConfig
 

--- a/web/features/channel/components/super-chat/chart/SupersMonthlyChart.tsx
+++ b/web/features/channel/components/super-chat/chart/SupersMonthlyChart.tsx
@@ -32,7 +32,7 @@ export default function SupersMonthlyChart({ supersMonthlySummaries }: Props) {
   const chartConfig = {
     thisMonth: {
       label: feat('monthly.label'),
-      color: 'var(--chart-1)'
+      color: 'var(--chart-3)'
     }
   } satisfies ChartConfig
 

--- a/web/features/stream-volume-trend/components/StreamVolumeTrendChart.tsx
+++ b/web/features/stream-volume-trend/components/StreamVolumeTrendChart.tsx
@@ -44,11 +44,11 @@ export function StreamVolumeTrendChart({ data }: Props) {
   const chartConfig: ChartConfig = {
     streamCount: {
       label: t('streamCount'),
-      color: 'var(--chart-5)'
+      color: 'var(--chart-3)'
     },
     totalDurationHours: {
       label: t('totalDurationHours'),
-      color: 'var(--chart-2)'
+      color: 'var(--chart-1)'
     }
   }
 


### PR DESCRIPTION
## Summary
- 全体的なチャート色（chart-1〜5）のCSS変数を変更
- 各チャートコンポーネントで使用する色変数を適切に更新

## Test plan
- [x] ライブ配信収益チャートの色を確認
- [x] 同時接続者数バーチャートの色を確認
- [x] スパチャ月次チャートの色を確認
- [x] 配信ボリュームトレンドチャートの色を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)