### PR TITLE
feat: SEO改善のためJSON-LD構造化データとXリンクを追加

### DIFF
--- a/web/app/[locale]/layout.tsx
+++ b/web/app/[locale]/layout.tsx
@@ -61,6 +61,20 @@ export default async function LocaleLayout(props: Props) {
         {/* Looker Studio ドメインへの事前接続でパフォーマンス向上 */}
         <link rel="preconnect" href="https://lookerstudio.google.com" />
         <link rel="dns-prefetch" href="https://lookerstudio.google.com" />
+        {/* 構造化データ: Organization と sameAs で公式Xアカウントとの関連を示す */}
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              '@context': 'https://schema.org',
+              '@type': 'Organization',
+              name: 'VCharts',
+              url: 'https://www.vcharts.net',
+              logo: 'https://www.vcharts.net/icon.svg',
+              sameAs: ['https://x.com/VCharts_net']
+            })
+          }}
+        />
       </head>
       <ClarityScript />
       <GoogleTagManager gtmId={process.env.NEXT_PUBLIC_GA_ID as string} />

--- a/web/components/aside/Aside.tsx
+++ b/web/components/aside/Aside.tsx
@@ -12,6 +12,7 @@ import {
 import AsideIcon from 'components/aside/AsideIcon'
 import { SettingsDropdown } from 'components/aside/SettingsDropdown'
 import PrivacyPolicyIcon from 'components/icons/PrivacyPolicyIcon'
+import XIcon from 'components/icons/XIcon'
 import AsideSkeleton from 'components/skeleton/AsideSkeleton'
 import { getGroups } from 'hooks/useGroups'
 import { auth } from 'lib/auth'
@@ -137,6 +138,23 @@ export default async function Aside({ className }: { className?: string }) {
                   </TooltipTrigger>
                   <TooltipContent side="right">
                     {comp('groupsAdd.title')}
+                  </TooltipContent>
+                </Tooltip>
+
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <a
+                      href="https://x.com/VCharts_net"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:text-foreground"
+                    >
+                      <XIcon className="size-5" />
+                      <span className="sr-only">{comp('aside.xAccount')}</span>
+                    </a>
+                  </TooltipTrigger>
+                  <TooltipContent side="right">
+                    {comp('aside.xAccount')}
                   </TooltipContent>
                 </Tooltip>
 

--- a/web/components/header/xs/HeaderXSSheet.tsx
+++ b/web/components/header/xs/HeaderXSSheet.tsx
@@ -21,6 +21,7 @@ import { ModeToggle } from 'components/ModeToggle'
 import HeaderLink from 'components/header/HeaderLink'
 import { SignOutInSheet } from 'components/header/xs/HeaderItem'
 import PrivacyPolicyIcon from 'components/icons/PrivacyPolicyIcon'
+import XIcon from 'components/icons/XIcon'
 import LanguageSwitcher from 'components/language-switcher/components/LanguageSwitcher'
 import { PWAInstallButton } from 'components/pwa/PWAInstallContext'
 import Image from 'components/styles/Image'
@@ -108,6 +109,18 @@ export default async function HeaderXSSheet() {
               icon={<UsersRound className="size-7" />}
               href="/groups/add"
             />
+
+            <a
+              href="https://x.com/VCharts_net"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-4 text-muted-foreground hover:text-foreground"
+            >
+              <div className="flex justify-center items-center h-8 w-8">
+                <XIcon className="size-6" />
+              </div>
+              <span className="flex-1">{comp('aside.xAccount')}</span>
+            </a>
 
             <HeaderLink
               name="Terms of Use and PP"

--- a/web/components/icons/XIcon.tsx
+++ b/web/components/icons/XIcon.tsx
@@ -1,0 +1,17 @@
+import { SVGProps } from 'react'
+
+export default function XIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      {...props}
+      role="img"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M18.901 1.153h3.68l-8.04 9.19L24 22.846h-7.406l-5.8-7.584-6.638 7.584H.474l8.6-9.83L0 1.154h7.594l5.243 6.932ZM17.61 20.644h2.039L6.486 3.24H4.298Z" />
+    </svg>
+  )
+}

--- a/web/config/i18n/messages/en.json
+++ b/web/config/i18n/messages/en.json
@@ -359,6 +359,7 @@
     "channelsAdd": { "title": "Add your channel to VCharts" },
     "groupsAdd": { "title": "Add your group to VCharts" },
     "contact": { "title": "Contact" },
+    "aside": { "xAccount": "Official X (formerly Twitter)" },
     "group": {
       "listing": "Listing {count} talents.",
       "listingAll": "All {count} talents are listed."

--- a/web/config/i18n/messages/ja.json
+++ b/web/config/i18n/messages/ja.json
@@ -370,6 +370,9 @@
     "contact": {
       "title": "お問い合わせ"
     },
+    "aside": {
+      "xAccount": "公式 X (旧 Twitter)"
+    },
     "group": {
       "listing": "{count}人のタレントを掲載中",
       "listingAll": "{count}人全員を掲載中!"


### PR DESCRIPTION
## Summary
- Organization型のJSON-LD構造化データを追加し、公式XアカウントとのsameAs関係を明示
- サイドバー（PC/スマホ）に公式Xアカウントへのリンクを追加
- XIconコンポーネントを新規作成

## 背景
Google検索でサービスサイトよりも公式Xアカウントが上位に表示されている問題を改善するため、SEO対策を実施。

## 変更内容
1. **JSON-LD構造化データ** (`web/app/[locale]/layout.tsx`)
   - `Organization`型でサイトとXアカウントの関連を明示
   - `sameAs`プロパティで公式Xアカウントを指定

2. **Xリンクの追加**
   - PC用サイドバー (`Aside.tsx`)
   - スマホ用サイドバー (`HeaderXSSheet.tsx`)
   - 「グループを登録したい」の下に配置

3. **新規ファイル**
   - `web/components/icons/XIcon.tsx`

4. **i18n対応**
   - `ja.json`: `公式 X (旧 Twitter)`
   - `en.json`: `Official X (formerly Twitter)`

## Test plan
- [x] PC表示でサイドバーにXリンクが表示される
- [x] スマホ表示でサイドバーにXリンクが表示される
- [x] Xリンクをクリックすると新しいタブで公式Xアカウントが開く
- [x] ページソースにJSON-LD構造化データが含まれる

🤖 Generated with [Claude Code](https://claude.com/claude-code)