### PR TITLE
fix: トップページチャートのSEO・アクセシビリティ改善

### DIFF
--- a/web/config/i18n/messages/en.json
+++ b/web/config/i18n/messages/en.json
@@ -876,12 +876,18 @@
       "title": "Live Stream Count Trend",
       "description": "Daily stream count (bar) and total duration (line)",
       "streamCount": "Stream Count",
-      "totalDurationHours": "Total Duration (h)"
+      "totalDurationHours": "Total Duration (h)",
+      "table": {
+        "date": "Date"
+      }
     },
     "concurrentViewerTrend": {
       "title": "Concurrent Viewers Trend",
       "description": "Daily concurrent viewers (median)",
-      "medianViewers": "Concurrent Viewers (Median)"
+      "medianViewers": "Concurrent Viewers (Median)",
+      "table": {
+        "date": "Date"
+      }
     }
   },
 

--- a/web/config/i18n/messages/ja.json
+++ b/web/config/i18n/messages/ja.json
@@ -890,12 +890,18 @@
       "title": "ライブ配信数トレンド",
       "description": "日別の配信件数（棒）と総配信時間（線）",
       "streamCount": "配信件数",
-      "totalDurationHours": "総配信時間 (h)"
+      "totalDurationHours": "総配信時間 (h)",
+      "table": {
+        "date": "日付"
+      }
     },
     "concurrentViewerTrend": {
       "title": "同時接続数トレンド",
       "description": "日別の同時接続数（中央値）",
-      "medianViewers": "同時接続数（中央値）"
+      "medianViewers": "同時接続数（中央値）",
+      "table": {
+        "date": "日付"
+      }
     }
   },
   "Pages": {

--- a/web/features/concurrent-viewer-trend/components/ConcurrentViewerTrendChart.tsx
+++ b/web/features/concurrent-viewer-trend/components/ConcurrentViewerTrendChart.tsx
@@ -103,9 +103,28 @@ export function ConcurrentViewerTrendChart({ data }: Props) {
               stroke="var(--color-medianViewers)"
               strokeWidth={1.5}
               dot={false}
+              isAnimationActive={false}
             />
           </LineChart>
         </ChartContainer>
+        {/* SEO・アクセシビリティ用: スクリーンリーダーとGooglebot向けのデータテーブル */}
+        <table className="sr-only">
+          <caption>{t('title')}</caption>
+          <thead>
+            <tr>
+              <th scope="col">{t('table.date')}</th>
+              <th scope="col">{t('medianViewers')}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.map(row => (
+              <tr key={row.date}>
+                <td>{row.date}</td>
+                <td>{format.number(row.medianViewers)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       </ChartCardContent>
     </ChartCard>
   )

--- a/web/features/stream-volume-trend/components/StreamVolumeTrendChart.tsx
+++ b/web/features/stream-volume-trend/components/StreamVolumeTrendChart.tsx
@@ -119,6 +119,7 @@ export function StreamVolumeTrendChart({ data }: Props) {
               fill="var(--color-streamCount)"
               // fillOpacity={0.7}
               radius={[2, 2, 0, 0]}
+              isAnimationActive={false}
             />
             <Line
               type="linear"
@@ -127,9 +128,30 @@ export function StreamVolumeTrendChart({ data }: Props) {
               stroke="var(--color-totalDurationHours)"
               strokeWidth={1.5}
               dot={false}
+              isAnimationActive={false}
             />
           </ComposedChart>
         </ChartContainer>
+        {/* SEO・アクセシビリティ用: スクリーンリーダーとGooglebot向けのデータテーブル */}
+        <table className="sr-only">
+          <caption>{t('title')}</caption>
+          <thead>
+            <tr>
+              <th scope="col">{t('table.date')}</th>
+              <th scope="col">{t('streamCount')}</th>
+              <th scope="col">{t('totalDurationHours')}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.map(row => (
+              <tr key={row.date}>
+                <td>{row.date}</td>
+                <td>{row.streamCount}</td>
+                <td>{row.totalDurationHours}h</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       </ChartCardContent>
     </ChartCard>
   )


### PR DESCRIPTION
## Summary

- Googlebotがトップページのチャートを空として認識する問題を修正
- Rechartsのアニメーションを無効化（Googlebotはアニメーション完了を待たない）
- sr-onlyテーブルを追加してデータをHTMLとして出力（SEO + アクセシビリティ）

## 変更内容

| ファイル | 変更 |
|---------|------|
| `StreamVolumeTrendChart.tsx` | `isAnimationActive={false}` 追加、sr-onlyテーブル追加 |
| `ConcurrentViewerTrendChart.tsx` | `isAnimationActive={false}` 追加、sr-onlyテーブル追加 |
| `ja.json` / `en.json` | `table.date` 翻訳キー追加 |

## 背景

Googlebotに認識されているトップページのチャートが空でした。原因は以下の2点:

1. **アニメーション**: Rechartsはデフォルトでアニメーションが有効。Googlebotはアニメーション完了を待たないため、データ描画前にスナップショットを撮っていた
2. **JavaScript依存**: チャートデータがJS経由でのみ描画されており、HTMLソースにテキストデータが存在しなかった

## Test plan

- [ ] トップページでチャートが正常に表示されることを確認
- [ ] ブラウザのデベロッパーツールでsr-onlyテーブルが存在することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)