### PR TITLE
feat: データ算出方法と免責事項ページを追加

### DIFF
--- a/web/app/[locale]/(end-user)/(default)/data-methodology-and-disclaimer/page.tsx
+++ b/web/app/[locale]/(end-user)/(default)/data-methodology-and-disclaimer/page.tsx
@@ -1,0 +1,41 @@
+import { use } from 'react'
+import { Metadata } from 'next'
+import { getTranslations, setRequestLocale } from 'next-intl/server'
+import { Page } from 'components/page'
+import DataMethodologyAndDisclaimer from 'features/data-methodology-and-disclaimer/DataMethodologyAndDisclaimer'
+
+type Props = {
+  params: Promise<{ locale: string }>
+}
+
+export async function generateMetadata(props: Props): Promise<Metadata> {
+  const params = await props.params
+  const { locale } = params
+  const tg = await getTranslations({
+    locale: locale as 'ja' | 'en',
+    namespace: 'Global'
+  })
+  const tp = await getTranslations({
+    locale: locale as 'ja' | 'en',
+    namespace: 'Pages.dataMethodologyAndDisclaimer'
+  })
+
+  return {
+    title: `${tp('title')} | ${tg('title')}`,
+    description: tp('description')
+  }
+}
+
+export default function DataMethodologyAndDisclaimerPage(props: Props) {
+  const params = use(props.params)
+  const { locale } = params
+
+  // Enable static rendering
+  setRequestLocale(locale as 'ja' | 'en')
+
+  return (
+    <Page breadcrumb={[{ href: '#', name: 'Data Methodology & Disclaimer' }]}>
+      <DataMethodologyAndDisclaimer />
+    </Page>
+  )
+}

--- a/web/components/aside/Aside.tsx
+++ b/web/components/aside/Aside.tsx
@@ -1,5 +1,11 @@
 import { Suspense } from 'react'
-import { Ellipsis, MailIcon, UserRoundPlus, UsersRound } from 'lucide-react'
+import {
+  Ellipsis,
+  FileChartLine,
+  MailIcon,
+  UserRoundPlus,
+  UsersRound
+} from 'lucide-react'
 import { getTranslations } from 'next-intl/server'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Separator } from '@/components/ui/separator'
@@ -155,6 +161,24 @@ export default async function Aside({ className }: { className?: string }) {
                   </TooltipTrigger>
                   <TooltipContent side="right">
                     {comp('aside.xAccount')}
+                  </TooltipContent>
+                </Tooltip>
+
+                <Tooltip>
+                  <TooltipTrigger>
+                    <Link
+                      href="/data-methodology-and-disclaimer"
+                      className="flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:text-foreground"
+                      prefetch={false}
+                    >
+                      <FileChartLine className="size-5.5" />
+                      <span className="sr-only">
+                        Data Methodology & Disclaimer
+                      </span>
+                    </Link>
+                  </TooltipTrigger>
+                  <TooltipContent side="right">
+                    Data Methodology & Disclaimer
                   </TooltipContent>
                 </Tooltip>
 

--- a/web/components/header/xs/HeaderXSSheet.tsx
+++ b/web/components/header/xs/HeaderXSSheet.tsx
@@ -1,5 +1,6 @@
 import {
   Ellipsis,
+  FileChartLine,
   LogOut,
   MailIcon,
   PanelLeftIcon,
@@ -121,6 +122,12 @@ export default async function HeaderXSSheet() {
               </div>
               <span className="flex-1">{comp('aside.xAccount')}</span>
             </a>
+
+            <HeaderLink
+              name="Data Methodology"
+              icon={<FileChartLine className="size-6.5" />}
+              href="/data-methodology-and-disclaimer"
+            />
 
             <HeaderLink
               name="Terms of Use and PP"

--- a/web/config/i18n/messages/en.json
+++ b/web/config/i18n/messages/en.json
@@ -913,6 +913,10 @@
   },
 
   "Pages": {
+    "dataMethodologyAndDisclaimer": {
+      "title": "Data Methodology & Disclaimer",
+      "description": "How VCharts calculates data and important notices"
+    },
     "groupsAdd": {
       "title": "Group Registration Application",
       "description": "Application form for registering a new VTuber group",

--- a/web/config/i18n/messages/ja.json
+++ b/web/config/i18n/messages/ja.json
@@ -925,6 +925,10 @@
     }
   },
   "Pages": {
+    "dataMethodologyAndDisclaimer": {
+      "title": "データ算出方法と免責事項",
+      "description": "VChartsが提供するデータの算出方法と注意事項について"
+    },
     "groupsAdd": {
       "title": "Group登録申請",
       "description": "新しいVTuberグループを登録するための申請フォーム",

--- a/web/features/data-methodology-and-disclaimer/DataMethodologyAndDisclaimer.tsx
+++ b/web/features/data-methodology-and-disclaimer/DataMethodologyAndDisclaimer.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { useLocale } from 'next-intl'
+import DataMethodologyAndDisclaimerEn from './DataMethodologyAndDisclaimerEn'
+import DataMethodologyAndDisclaimerJa from './DataMethodologyAndDisclaimerJa'
+
+export default function DataMethodologyAndDisclaimer() {
+  const locale = useLocale()
+
+  return (
+    <div>
+      {locale === 'ja' ? (
+        <DataMethodologyAndDisclaimerJa />
+      ) : (
+        <DataMethodologyAndDisclaimerEn />
+      )}
+    </div>
+  )
+}

--- a/web/features/data-methodology-and-disclaimer/DataMethodologyAndDisclaimerEn.tsx
+++ b/web/features/data-methodology-and-disclaimer/DataMethodologyAndDisclaimerEn.tsx
@@ -1,0 +1,143 @@
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle
+} from '@/components/ui/card'
+import { Separator } from '@/components/ui/separator'
+
+export default function DataMethodologyAndDisclaimerEn() {
+  return (
+    <div className="container mx-auto max-w-4xl py-12 px-4 md:px-6 mb-44">
+      <div className="space-y-8">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">
+            Data Methodology & Disclaimer
+          </h1>
+          <p className="mt-2 text-muted-foreground">
+            How VCharts calculates data and important notices
+          </p>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Overview & Population</CardTitle>
+            <CardDescription>About the data scope and targets</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <p className="text-sm leading-relaxed">
+              This report is based on measurement data independently collected by
+              VCharts. It does not guarantee the absolute value of talents or
+              their future profitability.
+            </p>
+            <div className="rounded-lg border p-3">
+              <p className="text-xs text-muted-foreground">Target</p>
+              <p className="text-lg font-semibold">
+                846 VCharts-registered talents
+              </p>
+              <p className="text-xs text-muted-foreground">As of December 2025</p>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Aggregation Definitions & Specifications</CardTitle>
+            <CardDescription>How each metric is calculated</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div className="space-y-3">
+              <h3 className="font-semibold">
+                Concurrent Viewers (Max CCV)
+              </h3>
+              <ul className="space-y-2 text-sm text-muted-foreground">
+                <li className="flex gap-2">
+                  <span className="text-primary">•</span>
+                  <span>
+                    We use the &quot;maximum concurrent viewers&quot; for each stream
+                  </span>
+                </li>
+                <li className="flex gap-2">
+                  <span className="text-primary">•</span>
+                  <span>
+                    Metrics such as &quot;median&quot; in reports are calculated based on
+                    these &quot;maximum values per stream&quot;
+                  </span>
+                </li>
+                <li className="flex gap-2">
+                  <span className="text-primary">•</span>
+                  <span>
+                    No bot filtering or corrections are applied; raw API values
+                    are used
+                  </span>
+                </li>
+                <li className="flex gap-2">
+                  <span className="text-primary">•</span>
+                  <span>Polling interval: 2 minutes</span>
+                </li>
+              </ul>
+            </div>
+
+            <Separator />
+
+            <div className="space-y-3">
+              <h3 className="font-semibold">Super Chat</h3>
+              <ul className="space-y-2 text-sm text-muted-foreground">
+                <li className="flex gap-2">
+                  <span className="text-primary">•</span>
+                  <span>
+                    To reduce server load, only events occurring between stream
+                    start and end are aggregated
+                  </span>
+                </li>
+                <li className="flex gap-2">
+                  <span className="text-primary">•</span>
+                  <span>
+                    Amounts during waiting rooms and premiere broadcasts are not
+                    included. Please note that totals may be lower than actual
+                  </span>
+                </li>
+                <li className="flex gap-2">
+                  <span className="text-primary">•</span>
+                  <span>
+                    When comment flow is extremely high, some data may be missed
+                    due to API limitations
+                  </span>
+                </li>
+                <li className="flex gap-2">
+                  <span className="text-primary">•</span>
+                  <span>Polling interval: 5 seconds</span>
+                </li>
+              </ul>
+            </div>
+
+            <Separator />
+
+            <div className="space-y-3">
+              <h3 className="font-semibold">Population Changes</h3>
+              <p className="text-sm text-muted-foreground leading-relaxed">
+                More than 300 talents have been added to the database during
+                the aggregation period. Please note that fluctuations and
+                trends, especially in the indie category, include this
+                &quot;increase in measurement targets&quot;.
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Disclaimer</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              Measurement logic may be adjusted without notice for quality
+              improvement. Important changes will be announced on the site or X.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/web/features/data-methodology-and-disclaimer/DataMethodologyAndDisclaimerJa.tsx
+++ b/web/features/data-methodology-and-disclaimer/DataMethodologyAndDisclaimerJa.tsx
@@ -1,0 +1,134 @@
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle
+} from '@/components/ui/card'
+import { Separator } from '@/components/ui/separator'
+
+export default function DataMethodologyAndDisclaimerJa() {
+  return (
+    <div className="container mx-auto max-w-4xl py-12 px-4 md:px-6 mb-44">
+      <div className="space-y-8">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">
+            データ算出方法と免責事項
+          </h1>
+          <p className="mt-2 text-muted-foreground">
+            VChartsが提供するデータの算出方法と注意事項について
+          </p>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>概要・母集団</CardTitle>
+            <CardDescription>
+              データの範囲と対象について
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <p className="text-sm leading-relaxed">
+              本レポートはVChartsが独自に収集した計測データに基づきます。タレントの絶対的な価値や将来の収益性を保証するものではありません。
+            </p>
+            <div className="rounded-lg border p-3">
+              <p className="text-xs text-muted-foreground">集計対象</p>
+              <p className="text-lg font-semibold">
+                VCharts登録済みタレント 846名
+              </p>
+              <p className="text-xs text-muted-foreground">2025年12月時点</p>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>集計定義と仕様</CardTitle>
+            <CardDescription>
+              各指標の算出方法について
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div className="space-y-3">
+              <h3 className="font-semibold">同時接続数（Max CCV）</h3>
+              <ul className="space-y-2 text-sm text-muted-foreground">
+                <li className="flex gap-2">
+                  <span className="text-primary">•</span>
+                  <span>各配信の「最大同時接続数」を採用します</span>
+                </li>
+                <li className="flex gap-2">
+                  <span className="text-primary">•</span>
+                  <span>
+                    レポート内の「中央値」等の指標は、この「各配信の最大値」を元に算出しています
+                  </span>
+                </li>
+                <li className="flex gap-2">
+                  <span className="text-primary">•</span>
+                  <span>
+                    Bot排除等の補正は行わずAPIの返却値を使用します
+                  </span>
+                </li>
+                <li className="flex gap-2">
+                  <span className="text-primary">•</span>
+                  <span>取得間隔：2分</span>
+                </li>
+              </ul>
+            </div>
+
+            <Separator />
+
+            <div className="space-y-3">
+              <h3 className="font-semibold">スーパーチャット</h3>
+              <ul className="space-y-2 text-sm text-muted-foreground">
+                <li className="flex gap-2">
+                  <span className="text-primary">•</span>
+                  <span>
+                    サーバ負荷軽減のためライブ配信開始から終了までの間に発生したイベントのみを集計します
+                  </span>
+                </li>
+                <li className="flex gap-2">
+                  <span className="text-primary">•</span>
+                  <span>
+                    待機所・プレミア公開中の金額は含みません。従って実際の総額より少ない集計となる点にご留意ください
+                  </span>
+                </li>
+                <li className="flex gap-2">
+                  <span className="text-primary">•</span>
+                  <span>
+                    コメント流速が極端に大きい場合、API仕様上一部取得漏れが発生する可能性があります
+                  </span>
+                </li>
+                <li className="flex gap-2">
+                  <span className="text-primary">•</span>
+                  <span>取得間隔：5秒</span>
+                </li>
+              </ul>
+            </div>
+
+            <Separator />
+
+            <div className="space-y-3">
+              <h3 className="font-semibold">母集団の変動について</h3>
+              <p className="text-sm text-muted-foreground leading-relaxed">
+                集計期間中にも300名以上のタレントが順次データベースに追加されています。
+                特に個人勢カテゴリにおける数値の変動やトレンドには、この「計測対象の増加」が含まれる点にご留意ください。
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>免責事項</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              計測ロジックは品質向上のため予告なく調整される場合があります。
+              重要な変更はサイトまたはXにて告知します。
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- 新規ページ `/data-methodology-and-disclaimer` を作成
- 日本語・英語のコンテンツコンポーネントを実装（shadcn Card使用）
- PC用Asideとモバイル用HeaderXSSheetにリンクを追加（terms-of-use-and-privacy-policyの上）
- i18nメッセージファイルを更新

## Test plan
- [x] `/ja/data-methodology-and-disclaimer` で日本語ページが表示されること
- [x] `/en/data-methodology-and-disclaimer` で英語ページが表示されること
- [x] PCでAsideに新しいリンクが表示されること
- [x] モバイルでHeaderXSSheetに新しいリンクが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)