### PR TITLE
feat: 応援ランキングAPIのキャッシュを強化

### DIFF
--- a/backend/apps/closed-api-server/src/presentation/cheer-ticket-usages/cheer-ticket-usages.controller.ts
+++ b/backend/apps/closed-api-server/src/presentation/cheer-ticket-usages/cheer-ticket-usages.controller.ts
@@ -1,3 +1,4 @@
+import { CacheInterceptor, CacheTTL } from '@nestjs/cache-manager'
 import {
   Body,
   ClassSerializerInterceptor,
@@ -45,6 +46,8 @@ export class CheerTicketUsagesController {
   }
 
   @Get('/rankings/cheered')
+  @UseInterceptors(CacheInterceptor)
+  @CacheTTL(24 * 3600 * 1000)
   async getCheeredRanking(@Query() dto: GetCheerTicketUsages) {
     return await this.cheerTicketUsagesService.findCheeredRanking({
       where: {
@@ -58,6 +61,8 @@ export class CheerTicketUsagesController {
   }
 
   @Get('/rankings/cheered/count')
+  @UseInterceptors(CacheInterceptor)
+  @CacheTTL(24 * 3600 * 1000)
   async getCheeredRankingCount(
     @Query() dto: GetCheerTicketUsagesWithoutLimitOffset
   ) {

--- a/web/apis/cheer-ticket-usages/getCheeredRanking.ts
+++ b/web/apis/cheer-ticket-usages/getCheeredRanking.ts
@@ -1,6 +1,7 @@
 import { AFTER_CONSUME_CHEER_TICKETS } from 'apis/tags/revalidate-tags'
 import { CACHE_1D, fetchAPI } from 'lib/fetchAPI'
 import { Gender } from 'types/gender'
+import { roundDateToDay } from 'utils/date'
 import {
   CheeredUsagesSchema,
   cheeredUsageListSchema
@@ -39,10 +40,18 @@ const createSearchParams = ({
   return searchParams
 }
 
-export async function getCheeredRanking(
-  params: Params
-): Promise<CheeredUsagesSchema> {
-  const searchParams = createSearchParams(params)
+export async function getCheeredRanking({
+  usedAt,
+  ...params
+}: Params): Promise<CheeredUsagesSchema> {
+  // 日付パラメータを日単位に丸めてキャッシュヒット率を向上
+  const searchParams = createSearchParams({
+    ...params,
+    usedAt: usedAt && {
+      gte: roundDateToDay(usedAt.gte),
+      lte: roundDateToDay(usedAt.lte)
+    }
+  })
   const res = await fetchAPI(
     `/api/cheer-ticket-usages/rankings/cheered?${searchParams.toString()}`,
     { next: { revalidate: CACHE_1D, tags: [AFTER_CONSUME_CHEER_TICKETS] } }
@@ -54,10 +63,18 @@ export async function getCheeredRanking(
   return data.list
 }
 
-export async function getCheeredRankingCount(
-  params: Omit<Params, 'limit' | 'offset'>
-): Promise<number> {
-  const searchParams = createSearchParams(params)
+export async function getCheeredRankingCount({
+  usedAt,
+  ...params
+}: Omit<Params, 'limit' | 'offset'>): Promise<number> {
+  // 日付パラメータを日単位に丸めてキャッシュヒット率を向上
+  const searchParams = createSearchParams({
+    ...params,
+    usedAt: usedAt && {
+      gte: roundDateToDay(usedAt.gte),
+      lte: roundDateToDay(usedAt.lte)
+    }
+  })
   const res = await fetchAPI(
     `/api/cheer-ticket-usages/rankings/cheered/count?${searchParams.toString()}`,
     { next: { revalidate: CACHE_1D, tags: [AFTER_CONSUME_CHEER_TICKETS] } }


### PR DESCRIPTION
## Summary
- フロントエンド: `gte`, `lte` を `roundDateToDay` で日単位に丸めてキャッシュヒット率を向上
- バックエンド: `CheerTicketUsagesController` の `/rankings/cheered` と `/rankings/cheered/count` に1日キャッシュを追加

## Test plan
- [ ] 応援ランキングページが正常に表示されること
- [ ] バックエンドでキャッシュが効いていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)