### PR TITLE
refactor: SuperChats APIから未使用のcreatedBeforeパラメータを削除

### DIFF
--- a/backend/apps/closed-api-server/src/presentation/supers/dto/GetSuperChats.dto.ts
+++ b/backend/apps/closed-api-server/src/presentation/supers/dto/GetSuperChats.dto.ts
@@ -28,10 +28,6 @@ export class GetSuperChats {
 
   @IsOptional()
   @IsRFC3339()
-  createdBefore?: string
-
-  @IsOptional()
-  @IsRFC3339()
   createdAfter?: string
 
   @IsOptional()
@@ -53,10 +49,6 @@ export class GetSuperChats {
     this.channelId ? new ChannelId(this.channelId) : undefined
 
   toUserComment = () => (this.userCommentNotNull ? { not: null } : undefined)
-
-  toCreatedBefore = () => {
-    return this.createdBefore ? new Date(this.createdBefore) : undefined
-  }
 
   toCreatedAfter = () => {
     return this.createdAfter ? new Date(this.createdAfter) : undefined

--- a/backend/apps/closed-api-server/src/presentation/supers/supers.controller.ts
+++ b/backend/apps/closed-api-server/src/presentation/supers/supers.controller.ts
@@ -25,7 +25,6 @@ export class SupersController {
         videoId: dto.toVideoId(),
         channelId: dto.toChannelId(),
         userComment: dto.toUserComment(),
-        createdBefore: dto.toCreatedBefore(),
         createdAfter: dto.toCreatedAfter()
       },
       orderBy: dto.toOrderBy(),
@@ -40,7 +39,6 @@ export class SupersController {
         videoId: dto.toVideoId(),
         channelId: dto.toChannelId(),
         userComment: dto.toUserComment(),
-        createdBefore: dto.toCreatedBefore(),
         createdAfter: dto.toCreatedAfter()
       }
     })

--- a/backend/libs/domain/supers/chat/SuperChat.repository.ts
+++ b/backend/libs/domain/supers/chat/SuperChat.repository.ts
@@ -9,7 +9,6 @@ export interface SuperChatRepository {
       channelId?: ChannelId
       userComment?: { not: null }
       group?: GroupId
-      createdBefore?: Date
       createdAfter?: Date
     }
     orderBy?: Partial<
@@ -27,7 +26,6 @@ export interface SuperChatRepository {
       channelId?: ChannelId
       userComment?: { not: null }
       group?: GroupId
-      createdBefore?: Date
       createdAfter?: Date
     }
   }) => Promise<number>

--- a/backend/libs/infrastructure/super-chat/SuperChat.repository-impl.ts
+++ b/backend/libs/infrastructure/super-chat/SuperChat.repository-impl.ts
@@ -9,14 +9,7 @@ export class SuperChatRepositoryImpl implements SuperChatRepository {
   constructor(private readonly prismaInfraService: PrismaInfraService) {}
 
   async findAll({
-    where: {
-      channelId,
-      userComment,
-      videoId,
-      group,
-      createdBefore,
-      createdAfter
-    },
+    where: { channelId, userComment, videoId, group, createdAfter },
     orderBy,
     limit
   }: Parameters<SuperChatRepository['findAll']>[0]) {
@@ -26,8 +19,7 @@ export class SuperChatRepositoryImpl implements SuperChatRepository {
         userComment,
         group: group?.get(),
         createdAt: {
-          gte: createdAfter,
-          lte: createdBefore
+          gte: createdAfter
         },
         stream: {
           channelId: channelId?.get()
@@ -42,14 +34,7 @@ export class SuperChatRepositoryImpl implements SuperChatRepository {
   }
 
   count: SuperChatRepository['count'] = async ({
-    where: {
-      channelId,
-      userComment,
-      videoId,
-      group,
-      createdBefore,
-      createdAfter
-    }
+    where: { channelId, userComment, videoId, group, createdAfter }
   }) => {
     return await this.prismaInfraService.youtubeStreamSuperChat.count({
       where: {
@@ -57,8 +42,7 @@ export class SuperChatRepositoryImpl implements SuperChatRepository {
         userComment,
         group: group?.get(),
         createdAt: {
-          gte: createdAfter,
-          lte: createdBefore
+          gte: createdAfter
         },
         stream: {
           channelId: channelId?.get()

--- a/web/apis/youtube/getSuperChats.ts
+++ b/web/apis/youtube/getSuperChats.ts
@@ -8,7 +8,6 @@ type Params = {
   videoId?: string
   channelId?: string
   userCommentNotNull?: boolean
-  createdBefore?: Date
   createdAfter?: Date
   orderBy: {
     field: 'commentLength' | 'amountMicros' | 'currency' | 'createdAt'
@@ -21,7 +20,6 @@ const createSearchParams = ({
   videoId,
   channelId,
   userCommentNotNull,
-  createdBefore,
   createdAfter,
   orderBy,
   limit
@@ -33,7 +31,6 @@ const createSearchParams = ({
     ...(userCommentNotNull && {
       userCommentNotNull: String(userCommentNotNull)
     }),
-    ...(createdBefore && { createdBefore: createdBefore.toISOString() }),
     ...(createdAfter && { createdAfter: createdAfter.toISOString() })
   })
 

--- a/web/features/supers/chat/components/SuperChatGallery.tsx
+++ b/web/features/supers/chat/components/SuperChatGallery.tsx
@@ -15,7 +15,6 @@ const FIRST_VIEW_LIMIT = 30
 type Props = {
   videoId?: string
   channelId?: string
-  createdBefore?: Date
   createdAfter?: Date
   limit?: number
 
@@ -26,7 +25,6 @@ type Props = {
 export default async function SuperChatGallery({
   videoId,
   channelId,
-  createdBefore,
   createdAfter,
   limit = 2000,
   showStreamLink = false
@@ -35,7 +33,6 @@ export default async function SuperChatGallery({
     getSuperChats({
       videoId,
       channelId,
-      createdBefore,
       createdAfter,
       orderBy: [
         { field: 'amountMicros', order: 'desc' },


### PR DESCRIPTION
## Summary
- キャッシュ強化の前準備として、使用されていないcreatedBeforeパラメータを削除
- 調査の結果、フロントエンドからこのパラメータが渡されている箇所がないことを確認

## 削除対象ファイル
- `web/apis/youtube/getSuperChats.ts`
- `web/features/supers/chat/components/SuperChatGallery.tsx`
- `backend/.../GetSuperChats.dto.ts`
- `backend/.../supers.controller.ts`
- `backend/.../SuperChat.repository.ts`
- `backend/.../SuperChat.repository-impl.ts`

## Test plan
- [ ] SuperChatの一覧取得が正常に動作すること
- [ ] SuperChatのカウント取得が正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)