### PR TITLE
fix: 曜日別トレンドチャートから今日を除外

### DIFF
--- a/backend/apps/closed-api-server/src/presentation/youtube/day-of-week-distributions/dto/get-day-of-week-distribution.dto.ts
+++ b/backend/apps/closed-api-server/src/presentation/youtube/day-of-week-distributions/dto/get-day-of-week-distribution.dto.ts
@@ -22,10 +22,11 @@ export class GetDayOfWeekDistributionDto {
     const month = jstNow.getUTCMonth()
     const day = jstNow.getUTCDate()
 
-    // JST 明日 00:00:00（今日の終わりまで含める）= UTC で -9時間
-    const lt = new Date(Date.UTC(year, month, day + 1, -9))
-    // JST (明日 - days日) 00:00:00
-    const gte = new Date(Date.UTC(year, month, day + 1 - this.days, -9))
+    // JST 今日 00:00:00（昨日の終わりまで含める = 今日を含まない）
+    // データ母集団が少ないため、今日を含むと時間帯によって変動が大きくなるため除外
+    const lt = new Date(Date.UTC(year, month, day, -9))
+    // JST (今日 - days日) 00:00:00
+    const gte = new Date(Date.UTC(year, month, day - this.days, -9))
 
     return { gte, lt }
   }


### PR DESCRIPTION
## Summary
- 曜日別トレンドチャートの集計期間から今日を除外
- データ母集団が少ないため、今日を含むと閲覧時間帯によって当日の曜日の棒グラフが大きく変動する問題を解消
- 例: 28日間の場合、昨日以前の4週間を集計対象とする

## Test plan
- [x] 曜日別トレンドチャートで今日のデータが含まれていないことを確認
- [x] 7日間、28日間、90日間それぞれで正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)