### PR TITLE
fix: ORDER BY に id を追加してページングの安定性を確保

### DIFF
--- a/backend/apps/groups/update-channels/src/scenario/main.scenario.ts
+++ b/backend/apps/groups/update-channels/src/scenario/main.scenario.ts
@@ -48,7 +48,7 @@ export class MainScenario {
     while (true) {
       try {
         const channels = await this.channelsService.findAll({
-          orderBy: [{ subscriberCount: 'desc' }],
+          orderBy: [{ subscriberCount: 'desc' }, { id: 'asc' }],
           limit: this.CHUNK_SIZE,
           offset
         })

--- a/backend/apps/summarize-channels/src/scenario/main.scenario.ts
+++ b/backend/apps/summarize-channels/src/scenario/main.scenario.ts
@@ -25,7 +25,7 @@ export class MainScenario {
     while (true) {
       try {
         const channels = await this.channelsService.findAll({
-          orderBy: [{ subscriberCount: 'desc' }],
+          orderBy: [{ subscriberCount: 'desc' }, { id: 'asc' }],
           limit: this.CHUNK_SIZE,
           offset
         })
@@ -64,7 +64,7 @@ export class MainScenario {
     while (true) {
       try {
         const channels = await this.channelsService.findAll({
-          orderBy: [{ subscriberCount: 'desc' }],
+          orderBy: [{ subscriberCount: 'desc' }, { id: 'asc' }],
           limit: this.CHUNK_SIZE,
           offset
         })

--- a/backend/libs/domain/youtube/channel/Channel.repository.ts
+++ b/backend/libs/domain/youtube/channel/Channel.repository.ts
@@ -19,7 +19,7 @@ export interface ChannelRepository {
       country?: CountryCode
     }
     orderBy?: Partial<
-      Record<'publishedAt' | 'subscriberCount' | 'viewCount', 'asc' | 'desc'>
+      Record<'id' | 'publishedAt' | 'subscriberCount' | 'viewCount', 'asc' | 'desc'>
     >[]
     limit?: number
     offset?: number


### PR DESCRIPTION
## Summary

- チャンネルのページング処理で ORDER BY が不安定なため、一部のチャンネルがスキップされる問題を修正
- `ORDER BY subscriberCount DESC` に `id ASC` を追加して、ソート順を一意に決定
- 影響を受けるバッチジョブ: `summarize-channels`, `update-channels`

## 問題の詳細

同じ `subscriberCount` を持つチャンネルが複数存在する場合、PostgreSQL の ORDER BY は順序を保証しません。
そのため、オフセットページング中にクエリごとに順序が変わり、一部のチャンネルが重複して取得されたり、スキップされたりする問題が発生していました。

### 証拠（デバッグ結果）

```
取得した全チャンネル数: 892
ユニークなチャンネル数: 889  ← 3件の差！

⚠️ 重複したチャンネル: 3 件
⚠️ スキップされたチャンネル: 2 件
```

## Test plan

- [x] 型チェック通過
- [x] lint 通過
- [ ] 次回 summarize-channels ジョブ実行後、問題のチャンネルが正しく更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)