### PR TITLE
feat: 主要ページにcanonicalタグを追加

### DIFF
--- a/web/app/[locale]/(end-user)/(default)/[group]/charts/channels/page.tsx
+++ b/web/app/[locale]/(end-user)/(default)/[group]/charts/channels/page.tsx
@@ -5,6 +5,7 @@ import { Page } from 'components/page'
 import LocalNavigationForGroupPages from 'features/group/local-navigation/LocalNavigationForGroupPages'
 import { ChannelGallerySearchParams } from 'features/group/types/channel-gallery'
 import { setGroup } from 'lib/server-only-context/cache'
+import { getWebUrl } from 'utils/web-url'
 import { ChartTemplate } from './_components/ChartTemplate'
 
 type Props = {
@@ -25,7 +26,10 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
 
   return {
     title: `${t('metadata.title', { group: groupName })} - ${tg('title')}`,
-    description: `${t('metadata.description', { group: groupName })}`
+    description: `${t('metadata.description', { group: groupName })}`,
+    alternates: {
+      canonical: `${getWebUrl()}/${locale}/${groupId}/charts/channels`
+    }
   }
 }
 

--- a/web/app/[locale]/(end-user)/(default)/[group]/ended/page.tsx
+++ b/web/app/[locale]/(end-user)/(default)/[group]/ended/page.tsx
@@ -5,6 +5,7 @@ import { Page } from 'components/page'
 import LocalNavigationForGroupPages from 'features/group/local-navigation/LocalNavigationForGroupPages'
 import { StreamGallerySearchParams } from 'features/group/types/stream-gallery'
 import { setGroup } from 'lib/server-only-context/cache'
+import { getWebUrl } from 'utils/web-url'
 import { IndexTemplate } from './_components/IndexTemplate'
 
 type Props = {
@@ -28,7 +29,10 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
 
   return {
     title: `${t('title', { group: groupName })} - ${tg('title')}`,
-    description: `${t('description', { group: groupName })}`
+    description: `${t('description', { group: groupName })}`,
+    alternates: {
+      canonical: `${getWebUrl()}/${locale}/${groupId}/ended`
+    }
   }
 }
 

--- a/web/app/[locale]/(end-user)/(default)/[group]/live/page.tsx
+++ b/web/app/[locale]/(end-user)/(default)/[group]/live/page.tsx
@@ -5,6 +5,7 @@ import { IndexTemplate } from 'app/[locale]/(end-user)/(default)/[group]/live/_c
 import { Page } from 'components/page'
 import LocalNavigationForGroupPages from 'features/group/local-navigation/LocalNavigationForGroupPages'
 import { setGroup } from 'lib/server-only-context/cache'
+import { getWebUrl } from 'utils/web-url'
 
 type Props = {
   params: Promise<{
@@ -26,7 +27,10 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
 
   return {
     title: `${t('title', { group: groupName })} - ${tg('title')}`,
-    description: `${t('description', { group: groupName })}`
+    description: `${t('description', { group: groupName })}`,
+    alternates: {
+      canonical: `${getWebUrl()}/${locale}/${groupId}/live`
+    }
   }
 }
 

--- a/web/app/[locale]/(end-user)/(default)/[group]/page.tsx
+++ b/web/app/[locale]/(end-user)/(default)/[group]/page.tsx
@@ -4,6 +4,7 @@ import { getGroupName } from 'apis/groups'
 import { Page } from 'components/page'
 import LocalNavigationForGroupPages from 'features/group/local-navigation/LocalNavigationForGroupPages'
 import { setGroup } from 'lib/server-only-context/cache'
+import { getWebUrl } from 'utils/web-url'
 import { IndexTemplate } from './_components/IndexTemplate'
 
 type Props = {
@@ -27,7 +28,10 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
 
   return {
     title: `${t('title', { group: groupName })} - ${tg('title')}`,
-    description: `${t('description', { group: groupName })}`
+    description: `${t('description', { group: groupName })}`,
+    alternates: {
+      canonical: `${getWebUrl()}/${locale}/${groupId}`
+    }
   }
 }
 

--- a/web/app/[locale]/(end-user)/(default)/[group]/scheduled/page.tsx
+++ b/web/app/[locale]/(end-user)/(default)/[group]/scheduled/page.tsx
@@ -5,6 +5,7 @@ import { IndexTemplate } from 'app/[locale]/(end-user)/(default)/[group]/schedul
 import { Page } from 'components/page'
 import LocalNavigationForGroupPages from 'features/group/local-navigation/LocalNavigationForGroupPages'
 import { setGroup } from 'lib/server-only-context/cache'
+import { getWebUrl } from 'utils/web-url'
 
 type Props = {
   params: Promise<{
@@ -26,7 +27,10 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
 
   return {
     title: `${t('title', { group: groupName })} - ${tg('title')}`,
-    description: `${t('description', { group: groupName })}`
+    description: `${t('description', { group: groupName })}`,
+    alternates: {
+      canonical: `${getWebUrl()}/${locale}/${groupId}/scheduled`
+    }
   }
 }
 

--- a/web/app/[locale]/(end-user)/(default)/about/page.tsx
+++ b/web/app/[locale]/(end-user)/(default)/about/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next'
 import { getTranslations, setRequestLocale } from 'next-intl/server'
 import { Page } from 'components/page'
+import { getWebUrl } from 'utils/web-url'
 
 type Props = {
   params: Promise<{ locale: string }>
@@ -22,7 +23,10 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
 
   return {
     title: `${t('title')} | ${tg('title')}`,
-    description: `${t('description')}`
+    description: `${t('description')}`,
+    alternates: {
+      canonical: `${getWebUrl()}/${locale}/about`
+    }
   }
 }
 

--- a/web/app/[locale]/(end-user)/(default)/contact/page.tsx
+++ b/web/app/[locale]/(end-user)/(default)/contact/page.tsx
@@ -3,6 +3,7 @@ import { Metadata } from 'next'
 import { getTranslations, setRequestLocale } from 'next-intl/server'
 import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert'
 import { Page } from 'components/page'
+import { getWebUrl } from 'utils/web-url'
 
 type Props = {
   params: Promise<{ locale: string }>
@@ -21,7 +22,10 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
 
   return {
     title: `${page('title')} - ${global('title')}`,
-    description: `${page('description')}`
+    description: `${page('description')}`,
+    alternates: {
+      canonical: `${getWebUrl()}/${locale}/contact`
+    }
   }
 }
 

--- a/web/app/[locale]/(end-user)/(default)/data-methodology-and-disclaimer/page.tsx
+++ b/web/app/[locale]/(end-user)/(default)/data-methodology-and-disclaimer/page.tsx
@@ -3,6 +3,7 @@ import { Metadata } from 'next'
 import { getTranslations, setRequestLocale } from 'next-intl/server'
 import { Page } from 'components/page'
 import DataMethodologyAndDisclaimer from 'features/data-methodology-and-disclaimer/DataMethodologyAndDisclaimer'
+import { getWebUrl } from 'utils/web-url'
 
 type Props = {
   params: Promise<{ locale: string }>
@@ -22,7 +23,10 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
 
   return {
     title: `${tp('title')} | ${tg('title')}`,
-    description: tp('description')
+    description: tp('description'),
+    alternates: {
+      canonical: `${getWebUrl()}/${locale}/data-methodology-and-disclaimer`
+    }
   }
 }
 

--- a/web/app/[locale]/(end-user)/(default)/groups/page.tsx
+++ b/web/app/[locale]/(end-user)/(default)/groups/page.tsx
@@ -5,6 +5,7 @@ import { getChannels } from 'apis/youtube/getChannels'
 import GroupGallery from 'components/group/GroupGallery'
 import { Page } from 'components/page'
 import { TalentSearch } from 'components/talent-search/components/TalentSearch'
+import { getWebUrl } from 'utils/web-url'
 
 type Props = {
   params: Promise<{ locale: string }>
@@ -24,7 +25,10 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
   })
   return {
     title: `${t('title')} - ${tg('title')}`,
-    description: `${t('description')}`
+    description: `${t('description')}`,
+    alternates: {
+      canonical: `${getWebUrl()}/${locale}/groups`
+    }
   }
 }
 

--- a/web/app/[locale]/(end-user)/(default)/legal/tokushoho/page.tsx
+++ b/web/app/[locale]/(end-user)/(default)/legal/tokushoho/page.tsx
@@ -2,6 +2,7 @@ import { use } from 'react'
 import { Metadata } from 'next'
 import { getTranslations, setRequestLocale } from 'next-intl/server'
 import { Page } from 'components/page'
+import { getWebUrl } from 'utils/web-url'
 import { LegalInformation } from './components/LegalInformation'
 
 type Props = {
@@ -18,7 +19,10 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
 
   return {
     title: `特定商取引法に基づく表記 | ${tg('title')}`,
-    description: `特定商取引法に基づく表記`
+    description: `特定商取引法に基づく表記`,
+    alternates: {
+      canonical: `${getWebUrl()}/${locale}/legal/tokushoho`
+    }
   }
 }
 

--- a/web/app/[locale]/(end-user)/(default)/monthly-pass/page.tsx
+++ b/web/app/[locale]/(end-user)/(default)/monthly-pass/page.tsx
@@ -9,14 +9,26 @@ import {
   CardTitle
 } from '@/components/ui/card'
 import { Link } from 'lib/navigation'
+import { getWebUrl } from 'utils/web-url'
 import { CheckoutButtonUsingDialog } from './components/CheckoutButtonUsingDialog'
 import { MonthlyPassFeatures } from './components/MonthlyPassFeatures'
 import type { Metadata } from 'next'
 
-export const metadata: Metadata = {
-  title: '月額パス - VCharts',
-  description:
-    'VChartsの月額パスに加入して、認証バッジの獲得や追加の応援チケットなどの特典をお楽しみください。'
+type Props = {
+  params: Promise<{ locale: string }>
+}
+
+export async function generateMetadata(props: Props): Promise<Metadata> {
+  const { locale } = await props.params
+
+  return {
+    title: '月額パス - VCharts',
+    description:
+      'VChartsの月額パスに加入して、認証バッジの獲得や追加の応援チケットなどの特典をお楽しみください。',
+    alternates: {
+      canonical: `${getWebUrl()}/${locale}/monthly-pass`
+    }
+  }
 }
 
 export default function MonthlyPassPage() {

--- a/web/app/[locale]/(end-user)/(default)/terms-of-use-and-privacy-policy/page.tsx
+++ b/web/app/[locale]/(end-user)/(default)/terms-of-use-and-privacy-policy/page.tsx
@@ -3,6 +3,7 @@ import { Metadata } from 'next'
 import { getTranslations, setRequestLocale } from 'next-intl/server'
 import { Page } from 'components/page'
 import TermsOfUseAndPrivacyPolicy from 'features/terms-of-use-and-privacy-policy/terms-of-use-and-privacy-policy'
+import { getWebUrl } from 'utils/web-url'
 
 type Props = {
   params: Promise<{ locale: string }>
@@ -18,7 +19,10 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
 
   return {
     title: `Terms of Use and Privacy Policy | ${tg('title')}`,
-    description: `Terms of Use and Privacy Policy`
+    description: `Terms of Use and Privacy Policy`,
+    alternates: {
+      canonical: `${getWebUrl()}/${locale}/terms-of-use-and-privacy-policy`
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- グループ関連ページ（概要、LIVE、スケジュール、終了、チャート）にcanonicalタグを追加
- 静的情報ページ（About、Contact、Groups一覧、利用規約、特商法、データ方法論）にcanonicalタグを追加
- マンスリーパスページにcanonicalタグを追加

## Test plan
- [ ] 各ページのHTMLソースを確認し、`<link rel="canonical">` が正しく出力されていることを確認
- [ ] locale（ja/en）に応じてcanonical URLが正しく生成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)