### PR TITLE
fix: OGP画像で「個人勢VTuber」を「個人勢V」に短縮

### DIFF
--- a/web/app/api/og/daily-ranking/route.tsx
+++ b/web/app/api/og/daily-ranking/route.tsx
@@ -36,8 +36,7 @@ export async function GET(request: Request) {
       : Promise.resolve('VTuber総合')
   ])
   // OGP画像用に短縮（テキストが長くなるため）
-  const groupName =
-    groupNameRaw === '個人勢VTuber' ? '個人勢V' : groupNameRaw
+  const groupName = groupNameRaw === '個人勢VTuber' ? '個人勢 V' : groupNameRaw
 
   const formatter = Intl.DateTimeFormat('ja-JP', {
     year: 'numeric',

--- a/web/app/api/og/monthly-ranking/route.tsx
+++ b/web/app/api/og/monthly-ranking/route.tsx
@@ -39,8 +39,7 @@ export async function GET(request: Request) {
       : Promise.resolve('VTuber総合')
   ])
   // OGP画像用に短縮（テキストが長くなるため）
-  const groupName =
-    groupNameRaw === '個人勢VTuber' ? '個人勢V' : groupNameRaw
+  const groupName = groupNameRaw === '個人勢VTuber' ? '個人勢 V' : groupNameRaw
 
   return new ImageResponse(
     (

--- a/web/app/api/og/weekly-ranking/route.tsx
+++ b/web/app/api/og/weekly-ranking/route.tsx
@@ -52,8 +52,7 @@ export async function GET(request: Request) {
       : Promise.resolve('VTuber総合')
   ])
   // OGP画像用に短縮（テキストが長くなるため）
-  const groupName =
-    groupNameRaw === '個人勢VTuber' ? '個人勢V' : groupNameRaw
+  const groupName = groupNameRaw === '個人勢VTuber' ? '個人勢 V' : groupNameRaw
 
   return new ImageResponse(
     (


### PR DESCRIPTION
## Summary

- OGP画像生成時に「個人勢VTuber」→「個人勢V」へ文言変更
- 画像化した時にテキストが長くやや窮屈なため、OGPのみの例外的な措置

## Changes

- `web/app/api/og/daily-ranking/route.tsx`
- `web/app/api/og/weekly-ranking/route.tsx`
- `web/app/api/og/monthly-ranking/route.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)