### PR TITLE
fix: X投稿のフッターテキストを変更

### DIFF
--- a/backend/apps/closed-api-server/src/presentation/x/x-last-24-hours.scenario.ts
+++ b/backend/apps/closed-api-server/src/presentation/x/x-last-24-hours.scenario.ts
@@ -112,7 +112,7 @@ export class XLast24HoursScenario {
         )}`
       })
       .join('\n')
-    const footer = `詳細・Top100はこちら`
+    const footer = `タップですべて表示`
     const url = `https://www.vcharts.net/ja/ranking/super-chat/channels${groupSlug}${periodSlug}?${searchParams.toString()}`
 
     const content = `${line1}\n${line2}\n\n${rankings}\n\n${footer}\n${url}`

--- a/backend/apps/closed-api-server/src/presentation/x/x-monthly.scenario.ts
+++ b/backend/apps/closed-api-server/src/presentation/x/x-monthly.scenario.ts
@@ -110,7 +110,7 @@ export class XMonthlyScenario {
         )}`
       })
       .join('\n')
-    const footer = `詳細・Top100はこちら`
+    const footer = `タップですべて表示`
     const url = `https://www.vcharts.net/ja/ranking/super-chat/channels${groupSlug}${periodSlug}${gender ? `?gender=${gender.get()}` : ''}`
 
     const content = `${line1}\n${line2}\n\n${rankings}\n\n${footer}\n${url}`

--- a/backend/apps/closed-api-server/src/presentation/x/x-weekly.scenario.ts
+++ b/backend/apps/closed-api-server/src/presentation/x/x-weekly.scenario.ts
@@ -118,7 +118,7 @@ export class XWeeklyScenario {
         )}`
       })
       .join('\n')
-    const footer = `詳細・Top100はこちら`
+    const footer = `タップですべて表示`
     const url = `https://www.vcharts.net/ja/ranking/super-chat/channels${groupSlug}${periodSlug}${gender ? `?gender=${gender.get()}` : ''}`
 
     const content = `${line1}\n${line2}\n\n${rankings}\n\n${footer}\n${url}`


### PR DESCRIPTION
## Summary
- X（Twitter）新Androidアプリでフッターテキスト「詳細・Top100はこちら」が途中で切れる問題への対応
- フッターテキストを「タップですべて表示」に変更
- 日次・週間・月間のX投稿すべてに適用

## Test plan
- [x] X投稿が正常に行われることを確認
- [x] 新Androidアプリで文字切れが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)