### PR TITLE
fix: Xランキング投稿からメダル絵文字を削除

### DIFF
--- a/backend/apps/closed-api-server/src/presentation/x/x-last-24-hours.scenario.ts
+++ b/backend/apps/closed-api-server/src/presentation/x/x-last-24-hours.scenario.ts
@@ -109,7 +109,7 @@ export class XLast24HoursScenario {
         )}`
       })
       .join('\n')
-    const footer = `タップですべて表示`
+    const footer = `画像タップですべて表示`
     const url = `https://www.vcharts.net/ja/ranking/super-chat/channels${groupSlug}${periodSlug}?${searchParams.toString()}`
 
     const content = `${line1}\n${line2}\n\n${rankings}\n\n${footer}\n${url}`

--- a/backend/apps/closed-api-server/src/presentation/x/x-monthly.scenario.ts
+++ b/backend/apps/closed-api-server/src/presentation/x/x-monthly.scenario.ts
@@ -107,7 +107,7 @@ export class XMonthlyScenario {
         )}`
       })
       .join('\n')
-    const footer = `タップですべて表示`
+    const footer = `画像タップですべて表示`
     const url = `https://www.vcharts.net/ja/ranking/super-chat/channels${groupSlug}${periodSlug}${gender ? `?gender=${gender.get()}` : ''}`
 
     const content = `${line1}\n${line2}\n\n${rankings}\n\n${footer}\n${url}`

--- a/backend/apps/closed-api-server/src/presentation/x/x-weekly.scenario.ts
+++ b/backend/apps/closed-api-server/src/presentation/x/x-weekly.scenario.ts
@@ -115,7 +115,7 @@ export class XWeeklyScenario {
         )}`
       })
       .join('\n')
-    const footer = `タップですべて表示`
+    const footer = `画像タップですべて表示`
     const url = `https://www.vcharts.net/ja/ranking/super-chat/channels${groupSlug}${periodSlug}${gender ? `?gender=${gender.get()}` : ''}`
 
     const content = `${line1}\n${line2}\n\n${rankings}\n\n${footer}\n${url}`


### PR DESCRIPTION
## Summary
- Xランキング投稿の1〜3位でメダル絵文字（🥇🥈🥉）を使用していたのをテキスト表記（1位. 2位. 3位.）に変更
- Android版Xアプリでfooterテキストが途切れる問題の対策

## Test plan
- [x] 型チェック・Lint・ユニットテスト通過済み
- [x] 本番環境でXへの投稿を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)