### PR TITLE
fix: スパチャ集計キャッシュクリアのcron時刻を3:05 JSTに変更

### DIFF
--- a/web/app/api/cron/cache-clear/supers/daily/route.ts
+++ b/web/app/api/cron/cache-clear/supers/daily/route.ts
@@ -4,7 +4,7 @@ import type { NextRequest } from 'next/server'
 
 /**
  * スパチャ金額集計のrevalidateを行う
- * １日に１回 18:00 JST のスケジューラが完了したあとを狙う
+ * １日に１回 3:00 JST のスケジューラが完了したあとを狙う
  */
 export function GET(request: NextRequest) {
   const authHeader = request.headers.get('authorization')

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -3,7 +3,7 @@
   "crons": [
     {
       "path": "/api/cron/cache-clear/supers/daily",
-      "schedule": "5 9 * * *"
+      "schedule": "5 18 * * *"
     },
     {
       "path": "/api/cron/cache-clear/supers/half-hourly",


### PR DESCRIPTION
## Summary
- SupersSummary作成バッチの実行時刻変更（18:00 JST → 3:00 JST）に合わせて、キャッシュクリアのcronを更新
- vercel.json: `5 9 * * *` (UTC) → `5 18 * * *` (UTC) = JST 3:05
- route.tsのコメントも更新

## Test plan
- [x] Vercelデプロイ後、cron設定が正しく反映されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)