### PR TITLE
feat: ライブ中カードにリアルタイム同接数ランキングへのリンクを追加

### DIFF
--- a/web/app/[locale]/(end-user)/(default)/_components/ui/live-stats/LiveStatsCards.tsx
+++ b/web/app/[locale]/(end-user)/(default)/_components/ui/live-stats/LiveStatsCards.tsx
@@ -1,9 +1,10 @@
 import { Suspense } from 'react'
-import { Radio } from 'lucide-react'
+import { ArrowRight, Radio } from 'lucide-react'
 import { getTranslations } from 'next-intl/server'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { getStreams } from 'apis/youtube/getStreams'
 import { CACHE_10M } from 'lib/fetchAPI'
+import { Link } from 'lib/navigation'
 import { LiveStatsCardsSkeleton } from './LiveStatsCardsSkeleton'
 
 function calculateMedian(numbers: number[]): number {
@@ -35,18 +36,34 @@ async function LiveStatsCardsContent() {
 
   return (
     <section className={'flex flex-col gap-2 lg:gap-4 h-full'}>
-      <Card className="flex-1 justify-center col-span-full gap-2 shadow-xs">
-        <CardHeader className="gap-0">
-          <CardTitle className="text-sm flex justify-start items-center gap-2 font-medium">
-            <Radio className="stroke-red-600 animate-pulse" /> {t('liveCount')}
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="text-2xl font-bold tabular-nums flex-1">
-            {liveCount.toLocaleString()}
-          </div>
-        </CardContent>
-      </Card>
+      <Link
+        href="/ranking/concurrent-viewer/live/all/realtime"
+        className="block group flex-1"
+        prefetch={false}
+      >
+        <Card className="h-full justify-center col-span-full gap-2 shadow-xs transition-all duration-100 ease-in-out group-hover:shadow-md group-hover:border-muted-foreground/20 cursor-pointer">
+          <CardHeader className="gap-0">
+            <CardTitle className="text-sm flex justify-between items-center font-medium">
+              <span className="flex items-center gap-2">
+                <Radio className="stroke-red-600 animate-pulse" size={16} />
+                {t('liveCount')}
+              </span>
+              <span className="flex items-center gap-1 text-xs text-muted-foreground group-hover:text-foreground transition-colors duration-200">
+                {t('viewRanking')}
+                <ArrowRight
+                  size={14}
+                  className="transition-transform duration-100 group-hover:translate-x-1"
+                />
+              </span>
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold tabular-nums">
+              {liveCount.toLocaleString()}
+            </div>
+          </CardContent>
+        </Card>
+      </Link>
 
       <div className="flex-1 flex md:flex-col lg:flex-row gap-2 lg:gap-4">
         <Card className="flex-1 justify-center gap-2 shadow-xs">

--- a/web/config/i18n/messages/en.json
+++ b/web/config/i18n/messages/en.json
@@ -100,6 +100,7 @@
       "section": {
         "liveStats": {
           "liveCount": "Live Now",
+          "viewRanking": "View Rankings",
           "totalViewers": "Total Viewers",
           "medianViewers": "Median Viewers"
         }

--- a/web/config/i18n/messages/ja.json
+++ b/web/config/i18n/messages/ja.json
@@ -94,6 +94,7 @@
       "section": {
         "liveStats": {
           "liveCount": "ライブ中",
+          "viewRanking": "ランキングを見る",
           "totalViewers": "現在の総同接数",
           "medianViewers": "同接数（中央値）"
         }


### PR DESCRIPTION
## Summary
- LiveStatsCardsの「ライブ中」カードをクリック可能なリンクに変更
- リンク先: `/ranking/concurrent-viewer/live/all/realtime`
- ホバーエフェクト（シャドウ増加、ボーダー変化、矢印スライドアニメーション）を追加
- 日英翻訳対応（`viewRanking`キー追加）

## Test plan
- [x] トップページの「ライブ中」カードをクリックしてランキングページに遷移することを確認
- [x] ホバー時のエフェクト（シャドウ、矢印アニメーション）が動作することを確認
- [x] 日本語・英語両方で「ランキングを見る」/「View Rankings」が表示されることを確認
- [x] モバイル・デスクトップ両方でレイアウトが崩れないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)