### PR TITLE
style: OGP画像のレイアウト調整

### DIFF
--- a/web/app/api/og/daily-ranking/route.tsx
+++ b/web/app/api/og/daily-ranking/route.tsx
@@ -53,14 +53,14 @@ export async function GET(request: Request) {
         display: 'flex',
         width: '100%',
         height: '100%',
-        padding: '34px 20px 34px 64px',
+        padding: '34px 24px 34px 34px',
         textAlign: 'center',
         justifyContent: 'center',
         alignItems: 'center',
-        gap: 40
+        gap: 44
       }}
     >
-      <section tw="flex flex-col items-start justify-between w-[480px] h-full text-4xl font-bold">
+      <section tw="flex flex-col items-start justify-between w-[520px] h-full text-4xl font-bold">
         <div tw="flex flex-col items-start mt-4" style={{ gap: 10 }}>
           <div style={{ fontSize: 30 }} tw="text-neutral-500">
             {formatter.format(dayjs(date).toDate())}

--- a/web/app/api/og/monthly-ranking/route.tsx
+++ b/web/app/api/og/monthly-ranking/route.tsx
@@ -49,14 +49,14 @@ export async function GET(request: Request) {
         display: 'flex',
         width: '100%',
         height: '100%',
-        padding: '34px 20px 34px 64px',
+        padding: '34px 24px 34px 34px',
         textAlign: 'center',
         justifyContent: 'center',
         alignItems: 'center',
-        gap: 40
+        gap: 44
       }}
     >
-      <section tw="flex flex-col items-start justify-between w-[480px] h-full text-4xl font-bold">
+      <section tw="flex flex-col items-start justify-between w-[520px] h-full text-4xl font-bold">
         <div tw="flex flex-col items-start mt-4" style={{ gap: 10 }}>
           <div style={{ display: 'flex', fontSize: 30 }} tw="text-neutral-500">
             {`${year}年 ${monthNum}月`}

--- a/web/app/api/og/weekly-ranking/route.tsx
+++ b/web/app/api/og/weekly-ranking/route.tsx
@@ -62,14 +62,14 @@ export async function GET(request: Request) {
         display: 'flex',
         width: '100%',
         height: '100%',
-        padding: '34px 20px 34px 64px',
+        padding: '34px 24px 34px 34px',
         textAlign: 'center',
         justifyContent: 'center',
         alignItems: 'center',
-        gap: 40
+        gap: 44
       }}
     >
-      <section tw="flex flex-col items-start justify-between w-[480px] h-full text-4xl font-bold">
+      <section tw="flex flex-col items-start justify-between w-[520px] h-full text-4xl font-bold">
         <div tw="flex flex-col items-start mt-4" style={{ gap: 10 }}>
           <div style={{ display: 'flex', fontSize: 30 }} tw="text-neutral-500">
             {`${year}年 第${weekNum}週 ${dateRange}`}


### PR DESCRIPTION
## Summary
- ランキングOGP画像のpadding、gap、左セクション幅を調整
- daily-ranking、weekly-ranking、monthly-ranking の3つのOGP画像に適用

## Test plan
- [x] 各OGP画像がブラウザで正常に表示されることを確認
  - `/api/og/daily-ranking?date=2026-01-10`
  - `/api/og/weekly-ranking?week=2026-W02`
  - `/api/og/monthly-ranking?month=2025-12`

🤖 Generated with [Claude Code](https://claude.com/claude-code)