### PR TITLE
fix: デイリーランキングOGPの日付を日本時間で表示

### DIFF
--- a/web/app/api/og/daily-ranking/route.tsx
+++ b/web/app/api/og/daily-ranking/route.tsx
@@ -5,6 +5,8 @@ import { getDailySupersRanking } from 'features/channels-ranking/utils/getDailyS
 import dayjs from 'lib/dayjs'
 import { Gender } from 'types/gender'
 import { getWebUrl } from 'utils/web-url'
+
+const DAY_OF_WEEK_JP = ['日', '月', '火', '水', '木', '金', '土'] as const
 // App router includes @vercel/og.
 // No need to install it.
 
@@ -22,7 +24,8 @@ export async function GET(request: Request) {
   const group = searchParams.get('group') as string
   const gender = searchParams.get('gender') as Gender | undefined
   const dateParam = searchParams.get('date')
-  const date = dateParam && dayjs(dateParam).isValid() ? dateParam : undefined
+  const date =
+    dateParam && dayjs(dateParam).isValid() ? dateParam : undefined
 
   const [ranking, groupNameRaw] = await Promise.all([
     getDailySupersRanking({
@@ -38,12 +41,9 @@ export async function GET(request: Request) {
   // OGP画像用に短縮（テキストが長くなるため）
   const groupName = groupNameRaw === '個人勢VTuber' ? '個人勢 V' : groupNameRaw
 
-  const formatter = Intl.DateTimeFormat('ja-JP', {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-    weekday: 'short'
-  })
+  /** 日本時間として解釈した日付 */
+  const jstDate = dayjs(date).tz('Asia/Tokyo')
+  const formattedDate = `${jstDate.format('YYYY/MM/DD')}（${DAY_OF_WEEK_JP[jstDate.day()]}）`
 
   return new ImageResponse(
     <div
@@ -63,7 +63,7 @@ export async function GET(request: Request) {
       <section tw="flex flex-col items-start justify-between w-[520px] h-full text-4xl font-bold">
         <div tw="flex flex-col items-start mt-4" style={{ gap: 10 }}>
           <div style={{ fontSize: 30 }} tw="text-neutral-500">
-            {formatter.format(dayjs(date).toDate())}
+            {formattedDate}
           </div>
           <div tw="text-neutral-500" style={{ fontSize: 50 }}>
             過去24hランキング

--- a/web/lib/dayjs.ts
+++ b/web/lib/dayjs.ts
@@ -5,6 +5,7 @@ import isoWeek from 'dayjs/plugin/isoWeek'
 import localizedFormat from 'dayjs/plugin/localizedFormat'
 import minMax from 'dayjs/plugin/minMax'
 import relativeTime from 'dayjs/plugin/relativeTime'
+import timezone from 'dayjs/plugin/timezone'
 import toArray from 'dayjs/plugin/toArray'
 import utc from 'dayjs/plugin/utc'
 
@@ -13,6 +14,7 @@ dayjs.extend(toArray)
 dayjs.extend(relativeTime)
 dayjs.extend(localizedFormat)
 dayjs.extend(utc)
+dayjs.extend(timezone)
 dayjs.extend(isoWeek)
 dayjs.extend(minMax)
 


### PR DESCRIPTION
## Summary
- デイリーランキング OGP の日付が1日古く表示される問題を修正
- dayjs に timezone プラグインを追加し、日本時間として日付を解釈するように変更

## Background
バッチが日本時間朝7時（= UTC 前日22時）に実行される際、`new Date().toISOString()` で生成される ISO 文字列は前日の日付になります。OGP 側でこれを UTC として解釈していたため、表示される日付が1日ずれていました。

## Changes
- `web/lib/dayjs.ts`: timezone プラグインを追加
- `web/app/api/og/daily-ranking/route.tsx`: `dayjs(date).tz('Asia/Tokyo')` で日本時間として解釈

## Test plan
- [x] 型チェック (`npm run type-check`)
- [x] Lint (`npm run lint`)
- [x] ユニットテスト (`npm test`)
- [x] E2E テスト (`cd e2e && npm test -- --grep "og-images"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)