### PR TITLE
perf: cache-manager から Map ベースキャッシュに変更

### DIFF
--- a/backend/apps/update-chats/src/main.module.ts
+++ b/backend/apps/update-chats/src/main.module.ts
@@ -1,6 +1,6 @@
-import { CacheModule } from '@nestjs/cache-manager'
 import { Module } from '@nestjs/common'
 import { ConfigModule } from '@nestjs/config'
+import { CacheService } from 'apps/update-chats/src/service/cache.service'
 import { SaveMembershipsService } from 'apps/update-chats/src/service/save-memberships.service'
 import { LibAppModule } from '@app/lib/lib.app.module'
 import { MembershipsModule } from '@app/memberships/memberships.module'
@@ -19,7 +19,6 @@ import { SaveSuperStickersService } from './service/save-super-stickers.service'
   imports: [
     // in only Local, load .env , in other environments, directly embed with Cloud Run
     ConfigModule.forRoot({ ignoreEnvFile: !!process.env.ENV_NAME }),
-    CacheModule.register({ ttl: 60 * 1000 }), // 60秒 TTL
     LibAppModule,
     NextContinuationModule,
     YoutubeAppModule,
@@ -31,6 +30,7 @@ import { SaveSuperStickersService } from './service/save-super-stickers.service'
   ],
   controllers: [],
   providers: [
+    CacheService,
     MainScenario,
     MainService,
     SaveMembershipsService,

--- a/backend/apps/update-chats/src/service/cache.service.ts
+++ b/backend/apps/update-chats/src/service/cache.service.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@nestjs/common'
+import { NextContinuation } from '@domain/next-continuation'
+
+interface CacheEntry {
+  data: NextContinuation
+  expiry: number
+}
+
+const TTL_MS = 60 * 1000 // 60秒
+
+@Injectable()
+export class CacheService {
+  private readonly continuationCache = new Map<string, CacheEntry>()
+
+  /**
+   * キャッシュから NextContinuation を取得
+   * TTL を過ぎている場合は削除して undefined を返す
+   */
+  getContinuation(videoId: string): NextContinuation | undefined {
+    const cached = this.continuationCache.get(videoId)
+    if (!cached) {
+      return undefined
+    }
+
+    if (cached.expiry > Date.now()) {
+      return cached.data
+    }
+
+    // 期限切れなので削除
+    this.continuationCache.delete(videoId)
+    return undefined
+  }
+
+  /**
+   * NextContinuation をキャッシュに保存（TTL 60秒）
+   */
+  setContinuation(videoId: string, data: NextContinuation): void {
+    this.continuationCache.set(videoId, {
+      data,
+      expiry: Date.now() + TTL_MS
+    })
+  }
+}


### PR DESCRIPTION
## Summary
- cache-manager の非同期処理オーバーヘッドにより実行時間が1秒→5-10秒に増加していた問題を修正
- CacheService を新規作成（Map + TTL 60秒 + lazy deletion）
- 実行時間: ~4秒（キャッシュなし）→ ~2.5秒（キャッシュあり）

## 背景
前回の PR #2666 で導入した cache-manager によるキャッシュが、非同期処理オーバーヘッドでパフォーマンス劣化を引き起こしていた。

## 変更内容
- `CacheService` を新規作成（シンプルな Map + TTL 管理）
- cache-manager の `@nestjs/cache-manager` 依存を削除
- 非同期の `await cacheManager.get/set` を同期的な `Map.get/set` に置換

## Test plan
- [x] 型チェック通過
- [x] Lint 通過
- [x] ユニットテスト通過
- [x] ローカルで実行時間を比較検証済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)