### PR TITLE
style: ランキングOGP画像のレイアウトを調整

### DIFF
--- a/web/app/api/og/daily-ranking/route.tsx
+++ b/web/app/api/og/daily-ranking/route.tsx
@@ -24,22 +24,19 @@ export async function GET(request: Request) {
   const group = searchParams.get('group') as string
   const gender = searchParams.get('gender') as Gender | undefined
   const dateParam = searchParams.get('date')
-  const date =
-    dateParam && dayjs(dateParam).isValid() ? dateParam : undefined
+  const date = dateParam && dayjs(dateParam).isValid() ? dateParam : undefined
 
-  const [ranking, groupNameRaw] = await Promise.all([
+  const [ranking, groupName] = await Promise.all([
     getDailySupersRanking({
       group,
       gender,
       date,
-      limit: 6
+      limit: 5
     }),
     group
       ? getGroupName(group, { errorContext: 'daily-ranking og image' })
       : Promise.resolve('VTuber総合')
   ])
-  // OGP画像用に短縮（テキストが長くなるため）
-  const groupName = groupNameRaw === '個人勢VTuber' ? '個人勢 V' : groupNameRaw
 
   /** 日本時間として解釈した日付 */
   const jstDate = dayjs(date).tz('Asia/Tokyo')
@@ -53,14 +50,14 @@ export async function GET(request: Request) {
         display: 'flex',
         width: '100%',
         height: '100%',
-        padding: '34px 24px 34px 34px',
+        padding: '24px 24px',
         textAlign: 'center',
         justifyContent: 'center',
         alignItems: 'center',
         gap: 44
       }}
     >
-      <section tw="flex flex-col items-start justify-between w-[520px] h-full text-4xl font-bold">
+      <section tw="flex flex-col items-start justify-between w-[530px] h-full text-4xl font-bold">
         <div tw="flex flex-col items-start mt-4" style={{ gap: 10 }}>
           <div style={{ fontSize: 30 }} tw="text-neutral-500">
             {formattedDate}
@@ -80,7 +77,7 @@ export async function GET(request: Request) {
         </div>
       </section>
 
-      <section style={{ gap: 12 }} tw="flex-1 flex flex-col">
+      <section style={{ gap: 16 }} tw="flex-1 flex flex-col">
         {ranking.map((e, i) => (
           <div key={i} style={{ gap: 20 }} tw="flex flex-row items-center">
             <div tw="flex items-baseline">
@@ -90,13 +87,13 @@ export async function GET(request: Request) {
               <span tw="text-2xl text-neutral-500">位</span>
             </div>
 
-            <div tw="flex w-[92px] h-[92px] justify-center items-center rounded-full overflow-hidden">
+            <div tw="flex w-[104px] h-[104px] justify-center items-center rounded-full overflow-hidden">
               <img
                 src={e.channelThumbnails}
                 alt={e.channelTitle}
                 style={{
-                  width: 92,
-                  height: 92,
+                  width: 104,
+                  height: 104,
                   objectFit: 'cover'
                 }}
               />

--- a/web/app/api/og/monthly-ranking/route.tsx
+++ b/web/app/api/og/monthly-ranking/route.tsx
@@ -26,20 +26,18 @@ export async function GET(request: Request) {
   const year = monthMatch ? monthMatch[1] : ''
   const monthNum = monthMatch ? parseInt(monthMatch[2], 10) : 0
 
-  const [ranking, groupNameRaw] = await Promise.all([
+  const [ranking, groupName] = await Promise.all([
     getSnapshotSupersRanking({
       period: 'monthly',
       target: month,
       group,
       gender,
-      limit: 6
+      limit: 5
     }),
     group
       ? getGroupName(group, { errorContext: 'monthly-ranking og image' })
       : Promise.resolve('VTuber総合')
   ])
-  // OGP画像用に短縮（テキストが長くなるため）
-  const groupName = groupNameRaw === '個人勢VTuber' ? '個人勢 V' : groupNameRaw
 
   return new ImageResponse(
     <div
@@ -49,14 +47,14 @@ export async function GET(request: Request) {
         display: 'flex',
         width: '100%',
         height: '100%',
-        padding: '34px 24px 34px 34px',
+        padding: '24px 24px',
         textAlign: 'center',
         justifyContent: 'center',
         alignItems: 'center',
         gap: 44
       }}
     >
-      <section tw="flex flex-col items-start justify-between w-[520px] h-full text-4xl font-bold">
+      <section tw="flex flex-col items-start justify-between w-[530px] h-full text-4xl font-bold">
         <div tw="flex flex-col items-start mt-4" style={{ gap: 10 }}>
           <div style={{ display: 'flex', fontSize: 30 }} tw="text-neutral-500">
             {`${year}年 ${monthNum}月`}
@@ -81,7 +79,7 @@ export async function GET(request: Request) {
         </div>
       </section>
 
-      <section style={{ gap: 12 }} tw="flex-1 flex flex-col">
+      <section style={{ gap: 16 }} tw="flex-1 flex flex-col">
         {ranking.map((e, i) => (
           <div key={i} style={{ gap: 20 }} tw="flex flex-row items-center">
             <div tw="flex items-baseline">
@@ -91,13 +89,13 @@ export async function GET(request: Request) {
               <span tw="text-2xl text-neutral-500">位</span>
             </div>
 
-            <div tw="flex w-[92px] h-[92px] justify-center items-center rounded-full overflow-hidden">
+            <div tw="flex w-[104px] h-[104px] justify-center items-center rounded-full overflow-hidden">
               <img
                 src={e.channelThumbnails}
                 alt={e.channelTitle}
                 style={{
-                  width: 92,
-                  height: 92,
+                  width: 104,
+                  height: 104,
                   objectFit: 'cover'
                 }}
               />

--- a/web/app/api/og/weekly-ranking/route.tsx
+++ b/web/app/api/og/weekly-ranking/route.tsx
@@ -39,20 +39,18 @@ export async function GET(request: Request) {
   const weekNum = weekMatch ? parseInt(weekMatch[2], 10) : 0
   const dateRange = weekMatch ? getWeekDateRange(year, weekNum) : ''
 
-  const [ranking, groupNameRaw] = await Promise.all([
+  const [ranking, groupName] = await Promise.all([
     getSnapshotSupersRanking({
       period: 'weekly',
       target: week,
       group,
       gender,
-      limit: 6
+      limit: 5
     }),
     group
       ? getGroupName(group, { errorContext: 'weekly-ranking og image' })
       : Promise.resolve('VTuber総合')
   ])
-  // OGP画像用に短縮（テキストが長くなるため）
-  const groupName = groupNameRaw === '個人勢VTuber' ? '個人勢 V' : groupNameRaw
 
   return new ImageResponse(
     <div
@@ -62,14 +60,14 @@ export async function GET(request: Request) {
         display: 'flex',
         width: '100%',
         height: '100%',
-        padding: '34px 24px 34px 34px',
+        padding: '24px 24px',
         textAlign: 'center',
         justifyContent: 'center',
         alignItems: 'center',
         gap: 44
       }}
     >
-      <section tw="flex flex-col items-start justify-between w-[520px] h-full text-4xl font-bold">
+      <section tw="flex flex-col items-start justify-between w-[530px] h-full text-4xl font-bold">
         <div tw="flex flex-col items-start mt-4" style={{ gap: 10 }}>
           <div style={{ display: 'flex', fontSize: 30 }} tw="text-neutral-500">
             {`${year}年 第${weekNum}週 ${dateRange}`}
@@ -94,7 +92,7 @@ export async function GET(request: Request) {
         </div>
       </section>
 
-      <section style={{ gap: 12 }} tw="flex-1 flex flex-col">
+      <section style={{ gap: 16 }} tw="flex-1 flex flex-col">
         {ranking.map((e, i) => (
           <div key={i} style={{ gap: 20 }} tw="flex flex-row items-center">
             <div tw="flex items-baseline">
@@ -104,13 +102,13 @@ export async function GET(request: Request) {
               <span tw="text-2xl text-neutral-500">位</span>
             </div>
 
-            <div tw="flex w-[92px] h-[92px] justify-center items-center rounded-full overflow-hidden">
+            <div tw="flex w-[104px] h-[104px] justify-center items-center rounded-full overflow-hidden">
               <img
                 src={e.channelThumbnails}
                 alt={e.channelTitle}
                 style={{
-                  width: 92,
-                  height: 92,
+                  width: 104,
+                  height: 104,
                   objectFit: 'cover'
                 }}
               />


### PR DESCRIPTION
## Summary
- ランキングOGP画像の表示件数を6件から5件に変更
- サムネイルサイズを92pxから104pxに拡大
- パディング・gap・セクション幅を微調整

## Test plan
- [x] `/api/og/daily-ranking?group=all` で画像が正常に生成されることを確認
- [x] `/api/og/weekly-ranking?group=all&week=2026-W02` で画像が正常に生成されることを確認
- [x] `/api/og/monthly-ranking?group=all&month=2025-12` で画像が正常に生成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)