### PR TITLE
perf: NextContinuation テーブルに createdAt インデックスを追加

### DIFF
--- a/backend/prisma/schema/migrations/20260112050619_add_next_continuation_created_at_index/migration.sql
+++ b/backend/prisma/schema/migrations/20260112050619_add_next_continuation_created_at_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "NextContinuation_createdAt_idx" ON "NextContinuation"("createdAt");

--- a/backend/prisma/schema/models/stream-stats.prisma
+++ b/backend/prisma/schema/models/stream-stats.prisma
@@ -16,6 +16,7 @@ model NextContinuation {
   createdAt         DateTime @default(now()) @db.Timestamptz(3)
 
   @@index([videoId, createdAt])
+  @@index([createdAt])
 }
 
 model StreamChatDeletingQueue {


### PR DESCRIPTION
## Summary
- `NextContinuation` テーブルの `createdAt` カラムに単体インデックスを追加
- `delete-chats` ジョブの `cleanOldRecords()` による DELETE クエリ（12秒）の高速化

## Background
`DELETE FROM "NextContinuation" WHERE "createdAt" <= $1` クエリが既存の複合インデックス `(videoId, createdAt)` を使用できず、フルテーブルスキャンが発生していた

## Test plan
- [ ] マイグレーション適用後、DELETE クエリの実行時間が改善されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)