### PR TITLE
feat: AdCard のインプレッション・クリックトラッキングを追加

### DIFF
--- a/web/app/[locale]/(end-user)/(default)/_components/IndexTemplate.tsx
+++ b/web/app/[locale]/(end-user)/(default)/_components/IndexTemplate.tsx
@@ -4,6 +4,7 @@ import { AdCardBeta } from 'components/ads/AdCardBeta'
 import { AdCarousel } from 'components/ads/AdCarousel'
 import { AdWantedFromFanCardBeta } from 'components/ads/AdWantedFromFanCardBeta'
 import { AdWantedFromTalentCardBeta } from 'components/ads/AdWantedFromTalentCardBeta'
+import { TrackableAdCard } from 'components/ads/TrackableAdCard'
 import { LookerReport } from 'components/looker/LookerReport'
 import {
   ChannelGrowthRankingContainer,
@@ -82,14 +83,15 @@ export async function IndexTemplate({ days = DEFAULT_DAYS, group }: Props) {
             className="max-w-[350px]"
             cards={[
               ...shuffledAdCards,
-              <AdCardBeta
-                key="sample"
-                type="fan"
-                videoUrl="https://www.youtube.com/watch?v=NsueHCfU1Ak"
-                channelUrl="https://www.youtube.com/@ShirakamiFubuki"
-                description="【サンプル】入稿時に指定した動画、チャンネル、メッセージはこのように表示されます。"
-                fanName="ファンの方の名前"
-              />
+              <TrackableAdCard key="sample" adId="sample-001" adType="fan">
+                <AdCardBeta
+                  type="fan"
+                  videoUrl="https://www.youtube.com/watch?v=NsueHCfU1Ak"
+                  channelUrl="https://www.youtube.com/@ShirakamiFubuki"
+                  description="【サンプル】入稿時に指定した動画、チャンネル、メッセージはこのように表示されます。"
+                  fanName="ファンの方の名前"
+                />
+              </TrackableAdCard>
             ]}
           />
           {/* ライブ統計カード（Above the fold） */}

--- a/web/components/ads/AdCardBeta.tsx
+++ b/web/components/ads/AdCardBeta.tsx
@@ -7,8 +7,6 @@ import { getChannel } from 'apis/youtube/data-api/getChannel'
 import { getVideo } from 'apis/youtube/data-api/getVideo'
 import Image from 'components/styles/Image'
 
-export type AdType = 'official' | 'fan'
-
 interface AdCardProps {
   /** 広告の種類（本人PR or ファン応援） */
   type: AdType

--- a/web/components/ads/TrackableAdCard.tsx
+++ b/web/components/ads/TrackableAdCard.tsx
@@ -1,0 +1,86 @@
+'use client'
+
+import { ReactNode, useCallback, useEffect, useRef } from 'react'
+import { useSearchParams } from 'next/navigation'
+import { usePathname } from 'lib/navigation'
+
+interface Props {
+  /** 広告の一意識別子 */
+  adId: string
+  /** 広告の種類 */
+  adType: AdType
+  children: ReactNode
+}
+
+/**
+ * 広告カードをラップしてインプレッション・クリックをトラッキングする
+ * - インプレッション: ビューポートに50%以上表示されたとき（URL 単位で1回）
+ * - クリック: カード内のクリック時
+ *
+ * URL（pathname + クエリストリング）が変わるたびに新しいインプレッションとしてカウント
+ */
+export function TrackableAdCard({ adId, adType, children }: Props) {
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const currentUrl = `${pathname}?${searchParams.toString()}`
+  const trackedUrl = useRef<string | null>(null)
+
+  const trackImpression = useCallback(() => {
+    // ref のアクセスは callback 内で行う（レンダー中にアクセスしない）
+    if (trackedUrl.current === currentUrl) return
+    trackedUrl.current = currentUrl
+    window.dataLayer?.push({
+      event: 'ad_impression',
+      ad_id: adId,
+      ad_type: adType
+    })
+  }, [currentUrl, adId, adType])
+
+  const handleClick = useCallback(() => {
+    window.dataLayer?.push({
+      event: 'ad_click',
+      ad_id: adId,
+      ad_type: adType
+    })
+  }, [adId, adType])
+
+  return (
+    <div onClick={handleClick}>
+      <TrackableAdCardImpression onImpression={trackImpression}>
+        {children}
+      </TrackableAdCardImpression>
+    </div>
+  )
+}
+
+interface ImpressionProps {
+  onImpression: () => void
+  children: ReactNode
+}
+
+/**
+ * Intersection Observer でインプレッションを検知する内部コンポーネント
+ */
+function TrackableAdCardImpression({ onImpression, children }: ImpressionProps) {
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          onImpression()
+          observer.disconnect()
+        }
+      },
+      { threshold: 0.5 }
+    )
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [onImpression])
+
+  return <div ref={ref}>{children}</div>
+}

--- a/web/global.d.ts
+++ b/web/global.d.ts
@@ -10,6 +10,16 @@ declare module 'next-intl' {
 }
 
 declare global {
+  interface Window {
+    dataLayer?: DataLayerEvent[]
+  }
+
+  type DataLayerEvent =
+    | { event: 'ad_impression'; ad_id: string; ad_type: AdType }
+    | { event: 'ad_click'; ad_id: string; ad_type: AdType }
+
+  type AdType = 'official' | 'fan'
+
   declare namespace NodeJS {
     interface ProcessEnv {
       /** the NODE_ENV */


### PR DESCRIPTION
## Summary
- GTM + dataLayer を使用した広告カード（AdCard）のトラッキング機能を実装
- `TrackableAdCard` コンポーネントを新規作成し、インプレッション・クリックを計測
- URL（pathname + クエリストリング）が変わるたびに新しいインプレッションとしてカウント

## Test plan
- [x] 型チェック・Lint・ユニットテストが通ることを確認済み
- [x] GTM 管理画面で変数・トリガー・タグを設定
- [x] プレビューモードで `ad_impression` / `ad_click` イベントの発火を確認
- [ ] GA4 リアルタイムレポートでイベントが記録されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)