### PR TITLE
fix: ad_impression イベント名を noxi_ad_impression に変更し遅延を削除

### DIFF
--- a/web/components/ads/TrackableAdCard.tsx
+++ b/web/components/ads/TrackableAdCard.tsx
@@ -38,7 +38,7 @@ export function TrackableAdCard({ adId, adType, children }: Props) {
 
   const handleClick = useCallback(() => {
     window.dataLayer?.push({
-      event: 'ad_click',
+      event: 'noxi_ad_click',
       ad_id: adId,
       ad_type: adType
     })

--- a/web/global.d.ts
+++ b/web/global.d.ts
@@ -16,7 +16,7 @@ declare global {
 
   type DataLayerEvent =
     | { event: 'noxi_ad_impression'; ad_id: string; ad_type: AdType }
-    | { event: 'ad_click'; ad_id: string; ad_type: AdType }
+    | { event: 'noxi_ad_click'; ad_id: string; ad_type: AdType }
 
   type AdType = 'official' | 'fan'
 


### PR DESCRIPTION
## Summary
- GA4 が `ad_impression` というイベント名を特別扱いしており、イベントが記録されない問題を修正
- イベント名を `noxi_ad_impression` に変更
- タイミングの問題ではなかったため、遅延処理を削除（リバート）

## Test plan
- [x] GA4 DebugView で `noxi_ad_impression` イベントが届くことを確認
- [x] GTM トリガーのイベント名も `noxi_ad_impression` に変更が必要

🤖 Generated with [Claude Code](https://claude.ai/code)