### PR TITLE
fix: チャンネルランキング「今年」のハイドレーションエラーを修正

### DIFF
--- a/e2e/tests/hydration.spec.ts
+++ b/e2e/tests/hydration.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect, ConsoleMessage } from '@playwright/test'
+
+/**
+ * ハイドレーションエラーのテスト
+ *
+ * React のハイドレーションエラーはコンソールに出力されるので、
+ * ページを開いてコンソールエラーを監視することで検出する。
+ */
+
+/** ハイドレーションエラーを示すキーワード */
+const HYDRATION_ERROR_PATTERNS = [
+  'Hydration failed',
+  'Text content does not match',
+  'There was an error while hydrating',
+  'Hydration mismatch'
+]
+
+/** コンソールメッセージがハイドレーションエラーかどうか判定 */
+function isHydrationError(msg: ConsoleMessage): boolean {
+  if (msg.type() !== 'error') return false
+  const text = msg.text()
+  return HYDRATION_ERROR_PATTERNS.some(pattern => text.includes(pattern))
+}
+
+test.describe('ハイドレーションエラーがないこと', () => {
+  test.describe('チャンネルランキング - 期間別', () => {
+    const periods = [
+      'last24Hours',
+      'last7Days',
+      'last30Days',
+      'thisWeek',
+      'thisMonth',
+      'thisYear'
+    ]
+
+    for (const period of periods) {
+      test(`スパチャランキング - ${period}`, async ({ page }) => {
+        const errors: string[] = []
+
+        page.on('console', msg => {
+          if (isHydrationError(msg)) {
+            errors.push(msg.text())
+          }
+        })
+
+        await page.goto(`/ja/ranking/super-chat/channels/all/${period}`)
+        await expect(page.locator('main')).toBeVisible()
+
+        // ハイドレーション完了を待つ
+        await page.waitForTimeout(1000)
+
+        expect(errors, `ハイドレーションエラーが発生: ${errors.join('\n')}`).toHaveLength(0)
+      })
+    }
+  })
+})

--- a/web/components/ranking/hover-card/RankingPeriodHoverCardFactory.tsx
+++ b/web/components/ranking/hover-card/RankingPeriodHoverCardFactory.tsx
@@ -1,6 +1,7 @@
 import { PropsWithChildren } from 'react'
 import { useTranslations } from 'next-intl'
 import PeriodHoverCard from 'components/ranking/hover-card/period/PeriodHoverCard'
+import dayjs from 'lib/dayjs'
 import { ChannelsRankingPeriod, Period, StreamRankingPeriod } from 'types/period'
 import { getEndOf, getStartOf, getUpdatedAt } from 'utils/period/ranking'
 
@@ -27,11 +28,11 @@ export default function PeriodHoverCardFactory({ type, period, date }: Props) {
 
   const regularPeriod = period as Period
 
-  let updatedAt: string | undefined
+  let updatedAt: dayjs.Dayjs | undefined
   let criteriaDescription = ''
   switch (type) {
     case 'channels':
-      updatedAt = getUpdatedAt(regularPeriod, date).toISOString()
+      updatedAt = getUpdatedAt(regularPeriod, date)
       criteriaDescription = comp('criteriaDescription.channels')
       break
     case 'live':
@@ -51,8 +52,8 @@ export default function PeriodHoverCardFactory({ type, period, date }: Props) {
   return (
     <div className="flex items-baseline gap-x-3">
       <PeriodHoverCard
-        start={getStartOf(regularPeriod, date).toISOString()}
-        end={getEndOf(regularPeriod, date).toISOString()}
+        start={getStartOf(regularPeriod, date)}
+        end={getEndOf(regularPeriod, date)}
         updatedAt={updatedAt}
         criteriaDescription={criteriaDescription}
       />

--- a/web/components/ranking/hover-card/base/RankingHoverCard.tsx
+++ b/web/components/ranking/hover-card/base/RankingHoverCard.tsx
@@ -1,11 +1,12 @@
 import { PropsWithChildren } from 'react'
 import { useFormatter } from 'next-intl'
+import dayjs from 'lib/dayjs'
 
-export const PopoverDate = ({ date }: { date: string }) => {
+export const PopoverDate = ({ date }: { date: dayjs.ConfigType }) => {
   const format = useFormatter()
   return (
     <div className="text-muted-foreground underline decoration-1 underline-offset-4 decoration-dashed decoration-slate-400 decoration">
-      {format.dateTime(new Date(date), {
+      {format.dateTime(dayjs(date).toDate(), {
         year: 'numeric',
         month: '2-digit',
         day: '2-digit',
@@ -39,11 +40,11 @@ export const DatetimeContainer = ({ children }: PropsWithChildren) => (
   <div className="grid grid-cols-[4rem_1fr] gap-2">{children}</div>
 )
 
-export const Datetime = ({ date }: { date: string }) => {
+export const Datetime = ({ date }: { date: dayjs.ConfigType }) => {
   const format = useFormatter()
   return (
     <div>
-      {format.dateTime(new Date(date), {
+      {format.dateTime(dayjs(date).toDate(), {
         dateStyle: 'medium',
         timeStyle: 'short'
       })}

--- a/web/components/ranking/hover-card/period/PeriodHoverCard.tsx
+++ b/web/components/ranking/hover-card/period/PeriodHoverCard.tsx
@@ -14,14 +14,12 @@ import {
   Item,
   Title
 } from 'components/ranking/hover-card/base/RankingHoverCard'
+import dayjs from 'lib/dayjs'
 
 type Props = {
-  /** ISO 8601 文字列 */
-  start: string
-  /** ISO 8601 文字列 */
-  end: string
-  /** ISO 8601 文字列 */
-  updatedAt?: string
+  start: dayjs.ConfigType
+  end: dayjs.ConfigType
+  updatedAt?: dayjs.ConfigType
   criteriaDescription: string
 }
 
@@ -34,8 +32,8 @@ export default function PeriodHoverCard({
   const t = useTranslations('Components.ranking.hoverCard')
   const format = useFormatter()
 
-  const formatDate = (dateString: string) =>
-    format.dateTime(new Date(dateString), {
+  const formatDate = (date: dayjs.ConfigType) =>
+    format.dateTime(dayjs(date).toDate(), {
       year: 'numeric',
       month: '2-digit',
       day: '2-digit',

--- a/web/utils/period/ranking.ts
+++ b/web/utils/period/ranking.ts
@@ -2,10 +2,11 @@ import dayjs from 'lib/dayjs'
 import { Period } from 'types/period'
 
 /**
- * 指定期間の開始時点を返す
+ * 指定期間の開始時点を返す（JST ベース）
+ * サーバー/クライアントで同じ結果を得るため、明示的に Asia/Tokyo で計算
  **/
 export const getStartOf = (period: Period, date?: dayjs.ConfigType) => {
-  const day = dayjs(date)
+  const day = dayjs(date).tz('Asia/Tokyo')
   let start: dayjs.Dayjs
 
   switch (period) {
@@ -34,7 +35,7 @@ export const getStartOf = (period: Period, date?: dayjs.ConfigType) => {
       start = day.startOf('year')
       break
     case 'wholePeriod':
-      start = dayjs(new Date(2020, 0, 1)) // 適当に固定値
+      start = dayjs.tz('2020-01-01', 'Asia/Tokyo') // 固定値
       break
     default:
       throw new Error(`Period ${period} is not supported`)
@@ -44,10 +45,11 @@ export const getStartOf = (period: Period, date?: dayjs.ConfigType) => {
 }
 
 /**
- * 指定期間の終了時点を返す
+ * 指定期間の終了時点を返す（JST ベース）
+ * サーバー/クライアントで同じ結果を得るため、明示的に Asia/Tokyo で計算
  */
 export const getEndOf = (period: Period, date?: dayjs.ConfigType) => {
-  const day = dayjs(date)
+  const day = dayjs(date).tz('Asia/Tokyo')
   let end: dayjs.Dayjs
 
   switch (period) {
@@ -77,13 +79,13 @@ export const getEndOf = (period: Period, date?: dayjs.ConfigType) => {
 }
 
 /**
- * 指定期間の「最新データ更新日時」を返す
+ * 指定期間の「最新データ更新日時」を返す（UTC ベース）
  *
  * 集計バッチがUTC18時（日本時間03時）に動くので基本その時点
  * 「過去24時間」だけは例外で30分間隔での集計
  */
 export const getUpdatedAt = (period: Period, date?: dayjs.ConfigType) => {
-  const day = dayjs(date)
+  const day = dayjs.utc(date)
   let updatedAt: dayjs.Dayjs
 
   switch (period) {


### PR DESCRIPTION
## Summary
- チャンネルランキングの「今年」ページでハイドレーションエラーが発生していた問題を修正
- `getStartOf` / `getEndOf` を JST ベース（`.tz('Asia/Tokyo')`）に統一し、サーバー/クライアントで同じタイムゾーンで計算するように変更
- `PeriodHoverCard` の props を `dayjs.ConfigType` に変更し、中間の文字列変換を排除

## 変更点
- `utils/period/ranking.ts`: `dayjs(date).tz('Asia/Tokyo')` で明示的に JST ベースで計算
- `PeriodHoverCard` 関連: props を `string` → `dayjs.ConfigType` に変更
- E2E テスト追加: 各期間でハイドレーションエラーがないことを検証

## 注意
「今週」「今月」「今年」の DB クエリ範囲が UTC ベースから JST ベースに変更されました（9時間の差）。日本向けサービスとしてはこちらが正しい動作です。

## Test plan
- [x] 型チェック通過
- [x] lint 通過
- [x] ユニットテスト通過
- [x] E2E テスト通過（ハイドレーションエラー検出テスト含む）
- [x] dev サーバーで「今年」ページの表示が正しいことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)