### PR TITLE
fix: スパチャランキング「今年」の最終更新日が未来日付になる問題を修正

### DIFF
--- a/web/components/ranking/hover-card/period/PeriodHoverCard.tsx
+++ b/web/components/ranking/hover-card/period/PeriodHoverCard.tsx
@@ -53,7 +53,7 @@ export default function PeriodHoverCard({
         <PopoverTrigger tabIndex={0} className="cursor-pointer">
           <div className="flex items-center gap-1.5 text-sm whitespace-nowrap">
             <span className="text-muted-foreground">{t('lastUpdated')}</span>
-            <PopoverDate date={end} />
+            <PopoverDate date={updatedAt ?? end} />
           </div>
         </PopoverTrigger>
         <PopoverContent className="text-sm space-y-4 font-normal">


### PR DESCRIPTION
## Summary
- スパチャランキング「今年」タブで最終更新日が「2026/12/31」と表示されていた問題を修正
- 集計期間の終了日（`end`）ではなく、バッチ実行時刻（`updatedAt`）を優先して表示するよう変更

## Test plan
- [x] 型チェック通過
- [x] lint 通過
- [x] ユニットテスト通過（42件）
- [x] E2Eテスト - ハイドレーションテスト（`スパチャランキング - thisYear`）通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)