### PR TITLE
fix: E2Eテストのフレーキー問題を修正

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -6,8 +6,8 @@ export default defineConfig({
   testDir: './tests',
   fullyParallel: true,
   forbidOnly: isCI,
-  retries: isCI ? 2 : 0,
-  workers: isCI ? 1 : undefined,
+  retries: isCI ? 2 : 1,
+  workers: isCI ? 1 : 4,
   reporter: isCI ? 'github' : 'html',
   use: {
     baseURL: 'http://localhost:3000',


### PR DESCRIPTION
## Summary
- ローカル実行時のワーカー数を 16 → 4 に制限
- ローカル実行時のリトライを 0 → 1 に設定

## 原因
Next.js dev server の JIT コンパイルが並列リクエストに追いつかず、JSON レスポンスが途切れる（`Unexpected end of JSON input`）

## Test plan
- [x] E2E テスト 55件すべて通過（35.9秒）

🤖 Generated with [Claude Code](https://claude.com/claude-code)