### PR TITLE
feat: fourte_project の推し広告を掲載

### DIFF
--- a/web/app/[locale]/(end-user)/(default)/_components/IndexTemplate.tsx
+++ b/web/app/[locale]/(end-user)/(default)/_components/IndexTemplate.tsx
@@ -1,9 +1,9 @@
 import { PropsWithChildren, Suspense } from 'react'
 import { getGroups } from 'apis/groups'
 import { AdCardBeta } from 'components/ads/AdCardBeta'
-import { AdCarousel } from 'components/ads/AdCarousel'
-import { AdWantedFromFanCardBeta } from 'components/ads/AdWantedFromFanCardBeta'
-import { AdWantedFromTalentCardBeta } from 'components/ads/AdWantedFromTalentCardBeta'
+// import { AdCarousel } from 'components/ads/AdCarousel'
+// import { AdWantedFromFanCardBeta } from 'components/ads/AdWantedFromFanCardBeta'
+// import { AdWantedFromTalentCardBeta } from 'components/ads/AdWantedFromTalentCardBeta'
 import { TrackableAdCard } from 'components/ads/TrackableAdCard'
 import { LookerReport } from 'components/looker/LookerReport'
 import {
@@ -20,10 +20,7 @@ import {
   DayOfWeekDistributionContainer,
   DayOfWeekDistributionSkeleton
 } from 'features/day-of-week-distribution'
-import {
-  GoldenTimeContainer,
-  GoldenTimeSkeleton
-} from 'features/golden-time'
+import { GoldenTimeContainer, GoldenTimeSkeleton } from 'features/golden-time'
 import {
   StreamVolumeTrendContainer,
   StreamVolumeTrendSkeleton
@@ -56,30 +53,30 @@ const FlexSection = (props: PropsWithChildren<{ className?: string }>) => {
 }
 
 /** サーバー側でシャッフル（リクエストごとに1回実行） */
-function shuffle<T>(array: T[]): T[] {
-  const shuffled = [...array]
-  for (let i = shuffled.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1))
-    ;[shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]]
-  }
-  return shuffled
-}
+// function shuffle<T>(array: T[]): T[] {
+//   const shuffled = [...array]
+//   for (let i = shuffled.length - 1; i > 0; i--) {
+//     const j = Math.floor(Math.random() * (i + 1))
+//     ;[shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]]
+//   }
+//   return shuffled
+// }
 
 export async function IndexTemplate({ days = DEFAULT_DAYS, group }: Props) {
   const groups = await getGroups()
 
   // サーバー側でランダム化
-  const shuffledAdCards = shuffle([
-    <AdWantedFromTalentCardBeta key="talent" />,
-    <AdWantedFromFanCardBeta key="fan" />
-  ])
+  // const shuffledAdCards = shuffle([
+  //   <AdWantedFromTalentCardBeta key="talent" />,
+  //   <AdWantedFromFanCardBeta key="fan" />
+  // ])
 
   return (
     <>
       <Container className="flex flex-col gap-6">
         <section className="flex items-center md:items-stretch flex-col md:flex-row gap-4">
           {/* AD Carousel */}
-          <AdCarousel
+          {/* <AdCarousel
             className="max-w-[350px]"
             cards={[
               ...shuffledAdCards,
@@ -93,7 +90,16 @@ export async function IndexTemplate({ days = DEFAULT_DAYS, group }: Props) {
                 />
               </TrackableAdCard>
             ]}
-          />
+          /> */}
+          <TrackableAdCard adId="fourte-project-001" adType="fan">
+            <AdCardBeta
+              type="fan"
+              videoUrl="https://www.youtube.com/live/PJBxfG_lKA4?si=VT6-vzONT7z3smhc"
+              channelUrl="https://youtube.com/@fourte_project"
+              description={"1/17(土)19時からの1stオンラインライブ！\n楽しみです！"}
+              className="max-w-[350px]"
+            />
+          </TrackableAdCard>
           {/* ライブ統計カード（Above the fold） */}
           <div className="flex-1 w-full @container">
             <LiveStatsCards />

--- a/web/components/ads/AdCardBeta.tsx
+++ b/web/components/ads/AdCardBeta.tsx
@@ -136,7 +136,7 @@ export async function AdCardBeta({
             rel="noopener noreferrer"
             className="block"
           >
-            <p className="text-sm text-foreground font-medium line-clamp-2">
+            <p className="text-sm text-foreground font-medium line-clamp-2 whitespace-pre-line">
               {description}
             </p>
           </a>


### PR DESCRIPTION
## Summary
- AD Carousel をコメントアウトし、fourte_project の推し広告を単独表示
- 1/17(土)19時からの1stオンラインライブ告知を掲載
- AdCardBeta の description で改行をサポート (whitespace-pre-line)

## Test plan
- [x] トップページで広告が正しく表示されることを確認
- [x] 改行が正しく表示されることを確認
- [x] 動画・チャンネルリンクが正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)