### PR TITLE
feat: super-adminページにBasic認証を追加

### DIFF
--- a/web/lib/middleware/withBasicAuth.ts
+++ b/web/lib/middleware/withBasicAuth.ts
@@ -1,0 +1,56 @@
+import { NextFetchEvent, NextMiddleware, NextRequest, NextResponse } from 'next/server'
+import { MiddlewareFactory } from 'lib/middleware/MiddlewareFactory'
+
+const SUPER_ADMIN_PATH = '/super-admin'
+
+/**
+ * Basic Authentication middleware for super-admin pages
+ * Protects /super-admin/* routes with HTTP Basic Auth
+ */
+export const withBasicAuth: MiddlewareFactory = (next: NextMiddleware) => {
+  return async (request: NextRequest, event: NextFetchEvent) => {
+    const pathname = request.nextUrl.pathname
+
+    // Extract locale from pathname (e.g., /ja/super-admin -> /super-admin)
+    const pathWithoutLocale = pathname.replace(/^\/[a-z]{2}/, '')
+
+    // Only apply to super-admin routes
+    if (!pathWithoutLocale.startsWith(SUPER_ADMIN_PATH)) {
+      return next(request, event)
+    }
+
+    const username = process.env.SUPER_ADMIN_USERNAME
+    const password = process.env.SUPER_ADMIN_PASSWORD
+
+    // Skip auth if credentials are not configured (development convenience)
+    if (!username || !password) {
+      console.warn(
+        'SUPER_ADMIN_USERNAME or SUPER_ADMIN_PASSWORD not set. Skipping auth.'
+      )
+      return next(request, event)
+    }
+
+    const authHeader = request.headers.get('authorization')
+
+    if (authHeader) {
+      const [scheme, encoded] = authHeader.split(' ')
+
+      if (scheme === 'Basic' && encoded) {
+        const decoded = atob(encoded)
+        const [user, pass] = decoded.split(':')
+
+        if (user === username && pass === password) {
+          return next(request, event)
+        }
+      }
+    }
+
+    // Return 401 with WWW-Authenticate header
+    return new NextResponse('Authentication required', {
+      status: 401,
+      headers: {
+        'WWW-Authenticate': 'Basic realm="Super Admin"'
+      }
+    })
+  }
+}

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -1,10 +1,12 @@
 import { NextRequest } from 'next/server'
 import { fromQueryStringsToPathParameters } from 'lib/middleware/fromQueryStringsToPathParameters'
 import { stackMiddlewares } from 'lib/middleware/stackMiddlewares'
+import { withBasicAuth } from 'lib/middleware/withBasicAuth'
 import { withIntl } from 'lib/middleware/withIntl'
 import { withRemoveQueryStrings } from 'lib/middleware/withRemoveQueryStrings'
 
 const middlewares = [
+  withBasicAuth,
   fromQueryStringsToPathParameters,
   withRemoveQueryStrings,
   withIntl


### PR DESCRIPTION
## Summary
- `/super-admin/*` パスに HTTP Basic 認証を追加
- 環境変数 `SUPER_ADMIN_USERNAME`, `SUPER_ADMIN_PASSWORD` で認証情報を設定
- 環境変数未設定時は認証をスキップ（開発時の利便性）

## Test plan
- [x] 環境変数を設定して `/super-admin` にアクセスし、認証ダイアログが表示されることを確認
- [x] 正しい認証情報でアクセスできることを確認
- [x] 誤った認証情報で 401 が返ることを確認
- [x] 環境変数未設定時は認証なしでアクセスできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)