### PR TITLE
feat: 配信スケジュールページのUI/UXを改善

### DIFF
--- a/e2e/tests/skeleton-height.spec.ts
+++ b/e2e/tests/skeleton-height.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * スケルトンと実コンポーネントの高さ一致テスト
+ *
+ * スケルトンUI表示中に取得した高さと、
+ * 実データ読み込み後のコンポーネントの高さが一致することを確認する。
+ * これにより、ローディング → 表示完了 時のレイアウトシフトを防ぐ。
+ */
+
+test.describe('スケルトンと実コンポーネントの高さ一致', () => {
+  test('配信スケジュール - アイテムの高さが一致', async ({ page }) => {
+    // ネットワークを遅延させてスケルトンを確実にキャプチャ
+    await page.route('**/api/youtube/streams**', async route => {
+      await new Promise(resolve => setTimeout(resolve, 500))
+      await route.continue()
+    })
+
+    await page.goto('/ja/hololive/scheduled')
+
+    // スケルトンアイテムの高さを取得
+    const skeletonItem = page.locator(
+      '[data-testid="scheduled-stream-skeleton-item"]'
+    )
+    await expect(skeletonItem.first()).toBeVisible({ timeout: 5000 })
+    const skeletonBox = await skeletonItem.first().boundingBox()
+
+    // 実データの読み込みを待つ
+    const actualItem = page.locator('[data-testid="scheduled-stream-item"]')
+    await expect(actualItem.first()).toBeVisible({ timeout: 30000 })
+    const actualBox = await actualItem.first().boundingBox()
+
+    // 両方の高さが取得できた場合のみ比較
+    if (skeletonBox && actualBox) {
+      const heightDiff = Math.abs(skeletonBox.height - actualBox.height)
+
+      // 高さの差が2px以内であることを確認
+      expect(
+        heightDiff,
+        `スケルトン(${skeletonBox.height}px)と実コンポーネント(${actualBox.height}px)の高さ差が${heightDiff}pxあります。2px以内に収めてください。`
+      ).toBeLessThanOrEqual(2)
+    }
+  })
+})

--- a/web/app/[locale]/(end-user)/(default)/[group]/scheduled/_components/IndexTemplate.tsx
+++ b/web/app/[locale]/(end-user)/(default)/[group]/scheduled/_components/IndexTemplate.tsx
@@ -1,17 +1,32 @@
-import { PropsWithoutRef } from 'react'
-import ScheduledStreamGallery from 'features/group/scheduled/components/ScheduledStreamGallery'
+import { Suspense } from 'react'
 import { getGroup } from 'lib/server-only-context/cache'
+import ScheduledStreamTimeline from './ScheduledStreamTimeline'
+import ScheduledStreamTimelineSkeleton from './ScheduledStreamTimelineSkeleton'
 
-type Props = {}
+const SCHEDULE_DAYS = 7
+const LOOKBACK_HOURS = 1 // 過去1時間からの配信も表示
 
-export async function IndexTemplate({}: PropsWithoutRef<Props>) {
+export async function IndexTemplate() {
+  const groupId = getGroup()
+  const now = new Date()
+  // 不純関数（Date.now）をコンポーネントのトップレベルで計算し、propsとして渡す
+  const scheduledBefore = new Date(
+    now.getTime() + SCHEDULE_DAYS * 24 * 60 * 60 * 1000
+  )
+  // 過去1時間からの配信も含める（直近で開始した配信を表示するため）
+  const scheduledAfter = new Date(
+    now.getTime() - LOOKBACK_HOURS * 60 * 60 * 1000
+  )
+
   return (
-    <>
-      <div className="grid grid-cols-4 gap-2 sm:gap-2">
-        <section className="col-span-full">
-          <ScheduledStreamGallery where={{ group: getGroup() }} />
-        </section>
-      </div>
-    </>
+    <section>
+      <Suspense fallback={<ScheduledStreamTimelineSkeleton />}>
+        <ScheduledStreamTimeline
+          groupId={groupId}
+          scheduledBefore={scheduledBefore}
+          scheduledAfter={scheduledAfter}
+        />
+      </Suspense>
+    </section>
   )
 }

--- a/web/app/[locale]/(end-user)/(default)/[group]/scheduled/_components/ScheduledDaySection.tsx
+++ b/web/app/[locale]/(end-user)/(default)/[group]/scheduled/_components/ScheduledDaySection.tsx
@@ -1,0 +1,75 @@
+import { getFormatter, getTranslations } from 'next-intl/server'
+import { ChannelsSchema } from 'apis/youtube/schema/channelSchema'
+import { StreamsSchema } from 'apis/youtube/schema/streamSchema'
+import dayjs from 'lib/dayjs'
+import ScheduledEmptyState from './ScheduledEmptyState'
+import ScheduledStreamItem from './ScheduledStreamItem'
+
+type Props = {
+  dateKey: string // 'YYYY-MM-DD'
+  streams: StreamsSchema
+  channels: ChannelsSchema
+}
+
+export default async function ScheduledDaySection({
+  dateKey,
+  streams,
+  channels
+}: Props) {
+  const t = await getTranslations('Features.schedule')
+  const format = await getFormatter()
+
+  const date = dayjs(dateKey).tz('Asia/Tokyo')
+  const today = dayjs().tz('Asia/Tokyo')
+  const isToday = date.isSame(today, 'day')
+  const isTomorrow = date.isSame(today.add(1, 'day'), 'day')
+
+  // 日付表示: "今日" or "明日" or "1/19（日）"
+  let dateLabel: string
+  if (isToday) {
+    dateLabel = t('today')
+  } else if (isTomorrow) {
+    dateLabel = t('tomorrow')
+  } else {
+    dateLabel = format.dateTime(date.toDate(), {
+      month: 'numeric',
+      day: 'numeric',
+      weekday: 'short'
+    })
+  }
+
+  const channelMap = new Map(channels.map(c => [c.basicInfo.id, c]))
+
+  return (
+    <section className="scroll-mt-20">
+      {/* 日付ヘッダー（sticky） */}
+      <div className="sticky top-14 z-40 -mx-4 mb-4 bg-muted/80 px-4 py-3 backdrop-blur supports-backdrop-filter:bg-muted/60">
+        <div className="flex items-baseline gap-3">
+          <h2 className="text-xl font-bold">{dateLabel}</h2>
+          <span className="text-sm text-muted-foreground">
+            {t('streamCount', { count: streams.length })}
+          </span>
+        </div>
+      </div>
+
+      {/* 配信リスト */}
+      {streams.length > 0 ? (
+        <div className="flex flex-col gap-3">
+          {streams.map(stream => {
+            const channel = channelMap.get(stream.snippet.channelId)
+            if (!channel) return null
+            return (
+              <ScheduledStreamItem
+                key={stream.videoId}
+                stream={stream}
+                channel={channel}
+              />
+            )
+          })}
+        </div>
+      ) : (
+        <ScheduledEmptyState />
+      )}
+    </section>
+  )
+}

--- a/web/app/[locale]/(end-user)/(default)/[group]/scheduled/_components/ScheduledEmptyState.tsx
+++ b/web/app/[locale]/(end-user)/(default)/[group]/scheduled/_components/ScheduledEmptyState.tsx
@@ -1,0 +1,15 @@
+import { CalendarOff } from 'lucide-react'
+import { getTranslations } from 'next-intl/server'
+
+export default async function ScheduledEmptyState() {
+  const t = await getTranslations('Features.schedule')
+
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-center">
+      <div className="rounded-full bg-muted p-4 mb-4">
+        <CalendarOff className="h-8 w-8 text-muted-foreground" />
+      </div>
+      <p className="text-sm text-muted-foreground">{t('noStreams')}</p>
+    </div>
+  )
+}

--- a/web/app/[locale]/(end-user)/(default)/[group]/scheduled/_components/ScheduledStreamItem.tsx
+++ b/web/app/[locale]/(end-user)/(default)/[group]/scheduled/_components/ScheduledStreamItem.tsx
@@ -1,0 +1,83 @@
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { Card } from '@/components/ui/card'
+import { ChannelSchema } from 'apis/youtube/schema/channelSchema'
+import { StreamSchema } from 'apis/youtube/schema/streamSchema'
+import LiveBadge from 'components/styles/badge/LiveBadge'
+import VideoThumbnail from 'components/youtube/video/VideoThumbnail'
+import dayjs from 'lib/dayjs'
+import { Link } from 'lib/navigation'
+
+function EndedBadge() {
+  return (
+    <div className="bg-muted text-muted-foreground text-xs font-medium px-1.5 py-0.5 rounded">
+      ENDED
+    </div>
+  )
+}
+
+type Props = {
+  stream: StreamSchema
+  channel: ChannelSchema
+}
+
+export default function ScheduledStreamItem({ stream, channel }: Props) {
+  const scheduledTime = stream.streamTimes.scheduledStartTime
+  const timeLabel = scheduledTime
+    ? dayjs(scheduledTime).tz('Asia/Tokyo').format('HH:mm')
+    : '--:--'
+  const isLive = stream.status === 'live'
+  const isEnded = stream.status === 'ended'
+
+  return (
+    <Link
+      href={`/youtube/live/${stream.videoId}`}
+      prefetch={false}
+      data-testid="scheduled-stream-item"
+    >
+      <Card className="py-3 overflow-hidden transition-all hover:shadow-lg hover:scale-[1.01] cursor-pointer">
+        <div className="flex p-3 md:p-4">
+          {/* 時刻 + ステータスバッジ */}
+          <div className="shrink-0 w-16 mr-4 md:mr-6 text-center flex flex-col items-center gap-1">
+            <time className="text-2xl font-bold tabular-nums text-foreground">
+              {timeLabel}
+            </time>
+            {isLive && <LiveBadge />}
+            {isEnded && <EndedBadge />}
+          </div>
+
+          {/* サムネイル */}
+          <div className="shrink-0 w-34 md:w-44 mr-2 md:mr-3">
+            <div className="relative aspect-video overflow-hidden rounded-sm bg-muted">
+              <VideoThumbnail
+                size="medium"
+                title={stream.snippet.title}
+                thumbnails={stream.snippet.thumbnails}
+              />
+            </div>
+          </div>
+
+          {/* 配信情報 */}
+          <div className="flex-1 min-w-0">
+            <h3 className="text-sm md:text-base font-semibold leading-snug line-clamp-2 break-all mb-3">
+              {stream.snippet.title}
+            </h3>
+            <div className="flex items-center gap-2">
+              <Avatar className="h-6 w-6">
+                <AvatarImage
+                  src={channel.basicInfo.thumbnails.default?.url}
+                  alt={channel.basicInfo.title}
+                />
+                <AvatarFallback>
+                  {channel.basicInfo.title.charAt(0)}
+                </AvatarFallback>
+              </Avatar>
+              <span className="text-sm text-muted-foreground truncate">
+                {channel.basicInfo.title}
+              </span>
+            </div>
+          </div>
+        </div>
+      </Card>
+    </Link>
+  )
+}

--- a/web/app/[locale]/(end-user)/(default)/[group]/scheduled/_components/ScheduledStreamTimeline.tsx
+++ b/web/app/[locale]/(end-user)/(default)/[group]/scheduled/_components/ScheduledStreamTimeline.tsx
@@ -1,0 +1,81 @@
+import { getChannels } from 'apis/youtube/getChannels'
+import { getStreams } from 'apis/youtube/getStreams'
+import { StreamsSchema } from 'apis/youtube/schema/streamSchema'
+import dayjs from 'lib/dayjs'
+import ScheduledDaySection from './ScheduledDaySection'
+import ScheduledEmptyState from './ScheduledEmptyState'
+
+const SCHEDULE_LIMIT = 100
+
+type Props = {
+  groupId: string
+  scheduledBefore: Date
+  scheduledAfter: Date
+}
+
+export default async function ScheduledStreamTimeline({
+  groupId,
+  scheduledBefore,
+  scheduledAfter
+}: Props) {
+  const streams = await getStreams({
+    group: groupId,
+    scheduledBefore,
+    scheduledAfter,
+    orderBy: [{ field: 'scheduledStartTime', order: 'asc' }],
+    limit: SCHEDULE_LIMIT,
+    offset: 0
+  })
+
+  if (streams.length === 0) {
+    return <ScheduledEmptyState />
+  }
+
+  // チャンネル情報をバッチ取得
+  const channelIds = [...new Set(streams.map(s => s.snippet.channelId))]
+  const channels = await getChannels({
+    ids: channelIds,
+    limit: channelIds.length
+  })
+
+  // 日付ごとにグループ化（Asia/Tokyo基準）
+  const groupedByDate = groupStreamsByDate(streams)
+
+  return (
+    <div className="space-y-8">
+      {Object.entries(groupedByDate).map(([dateKey, dayStreams]) => (
+        <ScheduledDaySection
+          key={dateKey}
+          dateKey={dateKey}
+          streams={dayStreams}
+          channels={channels}
+        />
+      ))}
+    </div>
+  )
+}
+
+function groupStreamsByDate(
+  streams: StreamsSchema
+): Record<string, StreamsSchema> {
+  const grouped: Record<string, StreamsSchema> = {}
+
+  streams.forEach(stream => {
+    const scheduledStartTime = stream.streamTimes.scheduledStartTime
+    if (!scheduledStartTime) return
+
+    // 日本時間でグループ化
+    const dateKey = dayjs(scheduledStartTime)
+      .tz('Asia/Tokyo')
+      .format('YYYY-MM-DD')
+
+    if (!grouped[dateKey]) {
+      grouped[dateKey] = []
+    }
+    grouped[dateKey].push(stream)
+  })
+
+  // streams は既に scheduledStartTime 昇順でソートされているため、
+  // 各日付グループ内も時間順（昇順）が維持されている
+  return grouped
+}

--- a/web/app/[locale]/(end-user)/(default)/[group]/scheduled/_components/ScheduledStreamTimelineSkeleton.tsx
+++ b/web/app/[locale]/(end-user)/(default)/[group]/scheduled/_components/ScheduledStreamTimelineSkeleton.tsx
@@ -1,0 +1,46 @@
+import { Card } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+
+const DAYS = 3
+const ITEMS_PER_DAY = 3
+
+export default function ScheduledStreamTimelineSkeleton() {
+  return (
+    <div className="space-y-8">
+      {/* 日付セクション x 3日分 */}
+      {Array.from({ length: DAYS }).map((_, dayIndex) => (
+        <section key={dayIndex}>
+          {/* 日付ヘッダー */}
+          <div className="sticky top-14 z-40 -mx-4 mb-4 bg-muted/80 px-4 py-3 backdrop-blur supports-[backdrop-filter]:bg-muted/60">
+            <div className="flex items-baseline gap-3">
+              <Skeleton className="h-7 w-16" />
+              <Skeleton className="h-4 w-24" />
+            </div>
+          </div>
+
+          {/* 配信アイテム x 3件 */}
+          <div className="space-y-3">
+            {Array.from({ length: ITEMS_PER_DAY }).map((_, i) => (
+              <Card key={i} className="py-3" data-testid="scheduled-stream-skeleton-item">
+                <div className="flex p-3 md:p-4">
+                  {/* 時刻 */}
+                  <Skeleton className="w-16 h-8 shrink-0 mr-4 md:mr-6" />
+                  {/* サムネイル */}
+                  <Skeleton className="w-34 md:w-44 aspect-video rounded-md shrink-0 mr-2 md:mr-3" />
+                  {/* 配信情報 */}
+                  <div className="flex-1 min-w-0">
+                    <Skeleton className="h-10 w-full max-w-md mb-3" />
+                    <div className="flex items-center gap-2">
+                      <Skeleton className="h-6 w-6 rounded-full" />
+                      <Skeleton className="h-4 w-24" />
+                    </div>
+                  </div>
+                </div>
+              </Card>
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  )
+}

--- a/web/config/i18n/messages/en.json
+++ b/web/config/i18n/messages/en.json
@@ -934,6 +934,12 @@
         "rank": "Fan ranking"
       }
     },
+    "schedule": {
+      "today": "Today",
+      "tomorrow": "Tomorrow",
+      "streamCount": "{count, plural, =0 {No scheduled streams} =1 {1 scheduled stream} other {# scheduled streams}}",
+      "noStreams": "No scheduled streams"
+    },
     "stream": {
       "noLive": "There are no live streams at the moment.",
       "noScheduled": "There are no scheduled streams at the moment.",

--- a/web/config/i18n/messages/ja.json
+++ b/web/config/i18n/messages/ja.json
@@ -281,7 +281,7 @@
       },
       "scheduled": {
         "metadata": {
-          "title": "{group} スケジュール - 高評価ランキング",
+          "title": "{group} 配信スケジュール",
           "description": "{group}の今後のライブ配信スケジュールを確認。お気に入りVTuberの配信を事前にチェックして見逃さないようにしよう。"
         }
       },
@@ -943,6 +943,12 @@
         "consumeCount": "チケット使用数",
         "rank": "ファン順位"
       }
+    },
+    "schedule": {
+      "today": "今日",
+      "tomorrow": "明日",
+      "streamCount": "{count}件の配信予定",
+      "noStreams": "配信予定はありません"
     },
     "stream": {
       "noLive": "現在配信中のライブはありません。",


### PR DESCRIPTION
## Summary

- 配信スケジュールページのデータ取得を改善（7日間・100件・時間順）
- UI/UXを日付セクション+縦型タイムラインに刷新
- LIVE/ENDEDバッジ、スケルトンローディング、高さ一致テストを追加

## Test plan

- [x] `/ja/hololive/scheduled` にアクセスして新UIが表示されることを確認
- [x] 日付ヘッダーがスクロール時にstickyで固定されることを確認
- [x] LIVE配信にはLIVEバッジ、終了配信にはENDEDバッジが表示されることを確認
- [x] `cd e2e && npx playwright test skeleton-height.spec.ts` でスケルトン高さテストがパスすることを確認
- [x] `cd web && npm run type-check && npm run lint` がパスすることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)