### PR TITLE
fix: VChartsロゴの色をテーマに応じて切り替え

### DIFF
--- a/web/components/vcharts/svg/icon.tsx
+++ b/web/components/vcharts/svg/icon.tsx
@@ -1,7 +1,5 @@
 import { PropsWithoutRef } from 'react'
 
-const COLOR = '#FC2F00'
-
 type Props = {
   className?: string
 }
@@ -15,12 +13,11 @@ export default function VChartsIcon({ className }: PropsWithoutRef<Props>) {
       height="500.000000pt"
       viewBox="0 0 500.000000 500.000000"
       preserveAspectRatio="xMidYMid meet"
-      className={`${className || ''}`}
+      className={className}
     >
       <g
         transform="translate(0.000000,500.000000) scale(0.100000,-0.100000)"
-        fill={COLOR}
-        stroke={COLOR}
+        className="fill-black stroke-black dark:fill-white dark:stroke-white"
         strokeWidth="150"
       >
         <path


### PR DESCRIPTION
## Summary
- VChartsロゴの色をテーマに応じて自動切り替えするよう変更
- ライトテーマ: 黒、ダークテーマ: 白
- ハードコードされたオレンジ色(`#FC2F00`)を削除

## Test plan
- [x] ライトテーマでロゴが黒色で表示されることを確認
- [x] ダークテーマでロゴが白色で表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)