### PR TITLE
feat: トップページにH1タグを追加（SEO対策）

### DIFF
--- a/web/app/[locale]/(end-user)/(default)/_components/IndexTemplate.tsx
+++ b/web/app/[locale]/(end-user)/(default)/_components/IndexTemplate.tsx
@@ -73,6 +73,7 @@ export async function IndexTemplate({ days = DEFAULT_DAYS, group }: Props) {
 
   return (
     <>
+      <h1 className="sr-only">VTuberランキング・統計 - VCharts</h1>
       <Container className="flex flex-col gap-6">
         <section className="flex items-center md:items-stretch flex-col md:flex-row gap-4">
           {/* AD Carousel */}


### PR DESCRIPTION
## Summary

- Bingの警告「H1タグがありません」に対応
- トップページにH1タグ（`VTuberランキング・統計 - VCharts`）を追加
- 視覚的にはロゴが存在するため、`sr-only`クラスで非表示に設定

## 背景

> <h1> タグは、本文コピーの主要なテーマまたはトピックが何であるかを Bingbot および Web の訪問者に示すインジケータです。

H1タグはSEOにおいて重要な要素の一つであり、検索エンジンにページの主題を明確に伝える役割があります。

## Test plan

- [x] トップページのHTMLソースにH1タグが含まれていることを確認
- [x] 視覚的にH1が表示されていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)