### PR TITLE
fix: チャンネル登録者数増加ランキングのSkeleton数を15に増加

### DIFF
--- a/web/features/channel-growth-ranking/components/ChannelGrowthRankingSkeleton.tsx
+++ b/web/features/channel-growth-ranking/components/ChannelGrowthRankingSkeleton.tsx
@@ -25,7 +25,7 @@ export function ChannelGrowthRankingSkeleton() {
           </div>
 
           {/* カードのスケルトン群 */}
-          {Array.from({ length: 8 }).map((_, i) => (
+          {Array.from({ length: 15 }).map((_, i) => (
             <div key={i} className="shrink-0 w-[100px]">
               <div className="relative flex flex-col">
                 {/* 順位 */}


### PR DESCRIPTION
## Summary
- トップページのチャンネル登録者数増加ランキングのSkeleton数を8から15に変更
- PCでは最大15個程度のアイテムが表示されるため、ローディング時のSkeleton数を実際の表示数に合わせた

## Test plan
- [ ] トップページを開き、チャンネル登録者数増加ランキングのローディング時にSkeletonが15個表示されることを確認
- [ ] ローディング完了後、レイアウトシフトが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)