### PR TITLE
perf: streams/:id エンドポイントに10分キャッシュを追加

### DIFF
--- a/backend/apps/closed-api-server/src/presentation/youtube/stream/streams.controller.ts
+++ b/backend/apps/closed-api-server/src/presentation/youtube/stream/streams.controller.ts
@@ -50,6 +50,7 @@ export class StreamsController {
   }
 
   @Get(':id')
+  @CacheTTL(600 * 1000)
   async getStream(@Param('id') id: string) {
     const stream = await this.streamsService.findOne({
       where: { videoId: new VideoId(id) }


### PR DESCRIPTION
## Summary
- `/streams/:id` エンドポイントに `@CacheTTL(600 * 1000)` を追加
- Cloud Run の総実行時間分析で最も負荷が高いエンドポイントであることが判明
- 同一 videoId への連続リクエストの DB アクセスを削減

## 背景
| エンドポイント | キャッシュ設定 |
|---------------|---------------|
| `GET /streams` | 10分 ✅ |
| `GET /streams/count` | 1時間 ✅ |
| `GET /streams/:id` | なし → **10分に変更** |

## Test plan
- [x] `npm run type-check` 通過
- [x] `npm run lint` 通過
- [x] `npm test` 通過

🤖 Generated with [Claude Code](https://claude.ai/code)