### PR TITLE
perf: PubsubhubbubScenario にチャンネル情報のインメモリキャッシュを追加

### DIFF
--- a/backend/apps/closed-api-server/src/presentation/youtube/pubsubhubbub/channel-cache.service.ts
+++ b/backend/apps/closed-api-server/src/presentation/youtube/pubsubhubbub/channel-cache.service.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@nestjs/common'
+import { Channel } from '@domain/youtube/channel/Channel.entity'
+
+interface CacheEntry {
+  data: Channel
+  expiry: number
+}
+
+const TTL_MS = 24 * 60 * 60 * 1000 // 1日
+
+@Injectable()
+export class ChannelCacheService {
+  private readonly cache = new Map<string, CacheEntry>()
+
+  /**
+   * キャッシュから Channel を取得
+   * TTL を過ぎている場合は削除して undefined を返す
+   */
+  get(channelId: string): Channel | undefined {
+    const cached = this.cache.get(channelId)
+    if (!cached) {
+      return undefined
+    }
+
+    if (cached.expiry > Date.now()) {
+      return cached.data
+    }
+
+    // 期限切れなので削除
+    this.cache.delete(channelId)
+    return undefined
+  }
+
+  /**
+   * Channel をキャッシュに保存
+   */
+  set(channelId: string, data: Channel): void {
+    this.cache.set(channelId, {
+      data,
+      expiry: Date.now() + TTL_MS
+    })
+  }
+}

--- a/backend/apps/closed-api-server/src/presentation/youtube/pubsubhubbub/pubsubhubbub.presentation.module.ts
+++ b/backend/apps/closed-api-server/src/presentation/youtube/pubsubhubbub/pubsubhubbub.presentation.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common'
+import { ChannelCacheService } from '@presentation/youtube/pubsubhubbub/channel-cache.service'
 import { CryptoService } from '@presentation/youtube/pubsubhubbub/crypto.service'
 import { PubsubhubbubController } from '@presentation/youtube/pubsubhubbub/pubsubhubbub.controller'
 import { ChatDeletingQueuesModule } from '@app/chat-deleting-queues/chat-deleting-queues.module'
@@ -21,6 +22,6 @@ import { PubsubhubbubScenario } from './pubsubhubbub.scenario'
     YoutubeAppModule
   ],
   controllers: [PubsubhubbubController],
-  providers: [PubsubhubbubScenario, CryptoService]
+  providers: [PubsubhubbubScenario, ChannelCacheService, CryptoService]
 })
 export class PubsubhubbubPresentationModule {}


### PR DESCRIPTION
## Summary
- `handleUpdatedCallback` での `channelsService.findById` 呼び出しにローカルキャッシュを導入
- 同一チャンネルへの連続リクエストの DB アクセスを削減

## 変更内容
| ファイル | 変更 |
|----------|------|
| `channel-cache.service.ts` | 新規作成 - TTL 1日のインメモリキャッシュ |
| `pubsubhubbub.scenario.ts` | `findChannelWithCache` メソッド追加 |
| `pubsubhubbub.presentation.module.ts` | `ChannelCacheService` を providers に追加 |

## 背景
PubSubHubbub コールバックは同一チャンネルの配信に対して短時間に複数回呼び出されることがある。
チャンネル情報は頻繁に変わらないため、インメモリキャッシュで DB 負荷を軽減できる。

## Test plan
- [x] `npm run type-check` 通過
- [x] `npm run lint` 通過
- [x] `npm test` 通過

🤖 Generated with [Claude Code](https://claude.ai/code)