### PR TITLE
feat: グループページにスパチャランキングへの導線を追加

### DIFF
--- a/web/config/i18n/messages/en.json
+++ b/web/config/i18n/messages/en.json
@@ -770,6 +770,9 @@
         "nav": "Past Live",
         "title": "Past Live Streams",
         "description": "Check out all of {group}'s past YouTube live streams!"
+      },
+      "superChatRanking": {
+        "nav": "Super Chat Ranking"
       }
     },
 

--- a/web/config/i18n/messages/ja.json
+++ b/web/config/i18n/messages/ja.json
@@ -785,6 +785,9 @@
         "nav": "過去のライブ",
         "title": "過去のライブ配信",
         "description": "{group}の過去のYouTubeライブ配信一覧です"
+      },
+      "superChatRanking": {
+        "nav": "スパチャランキング"
       }
     },
     "live": {

--- a/web/features/group/local-navigation/LocalNavigationForGroupPages.tsx
+++ b/web/features/group/local-navigation/LocalNavigationForGroupPages.tsx
@@ -28,7 +28,11 @@ export default function LocalNavigationForGroupPages({
           name: t('scheduled.nav'),
           href: `${basePath}/scheduled`
         },
-        { name: t('ended.nav'), href: `${basePath}/ended` }
+        { name: t('ended.nav'), href: `${basePath}/ended` },
+        {
+          name: t('superChatRanking.nav'),
+          href: `/ranking/super-chat/channels/${group}/last30Days`
+        }
       ]}
       className="mb-6"
     />


### PR DESCRIPTION
## Summary
- グループページのLocalNavigationに「スパチャランキング」タブを追加
- SEO施策として、グループページからランキングページへの内部リンクを設置
- リンク先: `/ranking/super-chat/channels/{group}/last30Days`

## Test plan
- [x] グループページ（例: `/ja/hololive`）にアクセスし、「スパチャランキング」タブが表示されることを確認
- [x] タブをクリックして、対応するスパチャランキングページに遷移することを確認
- [x] 英語版（`/en/hololive`）でも「Super Chat Ranking」タブが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)