### PR TITLE
chore: dependabot で vitest 関連パッケージをグループ化

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,10 @@ updates:
           - '@storybook/*'
         exclude-patterns:
           - '@storybook/testing-library'
+      vitest:
+        patterns:
+          - 'vitest'
+          - '@vitest/*'
     ignore:
       - dependency-name: '@types/node'
         versions: ['22.x.x', '21.x.x']


### PR DESCRIPTION
## Summary
- vitest と @vitest/* パッケージを dependabot のグループに追加
- バージョン不整合による CI 失敗を防止 (例: #2807)

## 関連
- Close 後、#2807 を close して dependabot に再生成させるか、手動で修正が必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)