### PR TITLE
feat: ライブ集計で週間/月間スナップショット期間をサポート

### DIFF
--- a/web/app/[locale]/(end-user)/(default)/ranking/[dimension]/channels/[group]/[period]/_components/ChannelsRankingJsonLd.tsx
+++ b/web/app/[locale]/(end-user)/(default)/ranking/[dimension]/channels/[group]/[period]/_components/ChannelsRankingJsonLd.tsx
@@ -19,8 +19,7 @@ import {
   getChannelsParams,
   getSupersSnapshotCountParams,
   getSupersSnapshotParams,
-  getSupersSummariesParams,
-  isSnapshotPeriod
+  getSupersSummariesParams
 } from 'features/channels-ranking/utils/gallery-params'
 import { ChannelsRankingPeriod, SnapshotPeriod } from 'types/period'
 import {
@@ -30,6 +29,7 @@ import {
   HubPageInfo
 } from 'utils/json-ld/buildRankingJsonLd'
 import { generateTitleAndDescription } from 'utils/metadata/metadata-generator'
+import { isSnapshotPeriod } from 'utils/period/snapshot-period'
 import { getWebUrl } from 'utils/web-url'
 
 type Props = {

--- a/web/app/[locale]/(end-user)/(default)/ranking/[dimension]/channels/[group]/[period]/page.tsx
+++ b/web/app/[locale]/(end-user)/(default)/ranking/[dimension]/channels/[group]/[period]/page.tsx
@@ -8,16 +8,16 @@ import {
   ChannelsRankingSearchParams
 } from 'features/channels-ranking/types/channels-ranking.type'
 import { getPeriodDisplayName } from 'features/channels-ranking/utils/formatSnapshotPeriod'
-import {
-  isSnapshotPeriod,
-  parseSnapshotPeriod
-} from 'features/channels-ranking/utils/gallery-params'
 import dayjs from 'lib/dayjs'
 import { ChannelsRankingPeriod } from 'types/period'
 import { buildUIBreadcrumbItems } from 'utils/json-ld/buildRankingJsonLd'
 import { getAlternates } from 'utils/metadata/getAlternates'
 import { generateTitleAndDescription } from 'utils/metadata/metadata-generator'
 import { getOgUrl } from 'utils/og-url'
+import {
+  isSnapshotPeriod,
+  parseSnapshotPeriod
+} from 'utils/period/snapshot-period'
 import { ChannelsRankingJsonLd } from './_components/ChannelsRankingJsonLd'
 import IndexTemplate from './_components/IndexTemplate'
 

--- a/web/components/ranking/filter/period/PeriodColumn.tsx
+++ b/web/components/ranking/filter/period/PeriodColumn.tsx
@@ -10,7 +10,7 @@ import {
   ColumnContent
 } from 'components/ranking/filter/column/Column'
 import { usePathname } from 'lib/navigation'
-import { Period, StreamRankingPeriod } from 'types/period'
+import { Period } from 'types/period'
 
 const RESET_KEYS = {
   date: null,
@@ -19,7 +19,8 @@ const RESET_KEYS = {
 
 // PeriodColumnはスナップショット期間（weekly-xxx, monthly-xxx）をサポートしない
 // スナップショットはUI選択ではなくURLから直接アクセスするため
-type Keys = Period | StreamRankingPeriod
+// StreamRankingPeriod に SnapshotPeriod が含まれるため、明示的に除外
+type Keys = Period | 'realtime'
 
 type Props = PropsWithoutRef<{
   keys: Keys[]

--- a/web/features/channels-ranking/components/gallery/ChannelsRankingGallery.tsx
+++ b/web/features/channels-ranking/components/gallery/ChannelsRankingGallery.tsx
@@ -13,12 +13,12 @@ import {
   ChannelsRankingSearchParams
 } from 'features/channels-ranking/types/channels-ranking.type'
 import { ChannelsRankingPeriod, SnapshotPeriod } from 'types/period'
+import { isSnapshotPeriod } from 'utils/period/snapshot-period'
 import {
   getChannelsParams,
   getSupersSnapshotCountParams,
   getSupersSnapshotParams,
-  getSupersSummariesParams,
-  isSnapshotPeriod
+  getSupersSummariesParams
 } from '../../utils/gallery-params'
 
 export type ChannelsRankingGalleryProps = ChannelsRankingSearchParams & {

--- a/web/features/channels-ranking/components/gallery/ChannelsRankingGalleryTitle.tsx
+++ b/web/features/channels-ranking/components/gallery/ChannelsRankingGalleryTitle.tsx
@@ -17,22 +17,13 @@ import { usePathname } from 'lib/navigation'
 import { Gender } from 'types/gender'
 import { ChannelsRankingPeriod, StreamRankingPeriod } from 'types/period'
 
-/** Channels → Live 遷移時の period フォールバック */
+/** Channels → Live 遷移時の period マッピング */
 function getStreamPeriodFromChannelsPeriod(
   period: ChannelsRankingPeriod
 ): StreamRankingPeriod {
-  // 共通の period はそのまま維持
-  const commonPeriods: StreamRankingPeriod[] = [
-    'last24Hours',
-    'last7Days',
-    'last30Days',
-    'thisYear'
-  ]
-  if (commonPeriods.includes(period as StreamRankingPeriod)) {
-    return period as StreamRankingPeriod
-  }
-  // Channels 固有の period は last30Days にフォールバック
-  return 'last30Days'
+  // StreamRankingPeriod が SnapshotPeriod を含むようになったため
+  // すべての ChannelsRankingPeriod はそのまま StreamRankingPeriod として使える
+  return period as StreamRankingPeriod
 }
 
 type Props = PropsWithChildren<{

--- a/web/features/channels-ranking/components/table/ChannelsRankingTable.tsx
+++ b/web/features/channels-ranking/components/table/ChannelsRankingTable.tsx
@@ -14,14 +14,12 @@ import ChannelTitle from 'components/ranking/table/styles/ChannelTitle'
 import Dimension from 'components/ranking/table/styles/Dimension'
 import { ChannelsRankingPagination as Pagination } from 'config/constants/Pagination'
 import { ChannelsRankingDimension } from 'features/channels-ranking/types/channels-ranking.type'
-import {
-  getSupersSnapshotParams,
-  isSnapshotPeriod
-} from 'features/channels-ranking/utils/gallery-params'
+import { getSupersSnapshotParams } from 'features/channels-ranking/utils/gallery-params'
 import { Gender } from 'types/gender'
 import { ChannelsRankingPeriod, Period, SnapshotPeriod } from 'types/period'
 import { convertMicrosToAmount } from 'utils/amount'
 import { rangeDatetimeForPreviousPeriod } from 'utils/period/period'
+import { isSnapshotPeriod } from 'utils/period/snapshot-period'
 import {
   getSupersRankingType,
   hasSupersRanking

--- a/web/features/channels-ranking/utils/formatSnapshotPeriod.ts
+++ b/web/features/channels-ranking/utils/formatSnapshotPeriod.ts
@@ -1,6 +1,13 @@
 import dayjs from 'lib/dayjs'
 import { ChannelsRankingPeriod, SnapshotPeriod } from 'types/period'
-import { isSnapshotPeriod, parseSnapshotPeriod } from './gallery-params'
+import {
+  formatSnapshotPeriod as formatSnapshotPeriodUtil,
+  isSnapshotPeriod,
+  parseSnapshotPeriod
+} from 'utils/period/snapshot-period'
+
+// 後方互換性のため re-export
+export { formatSnapshotPeriodUtil as formatSnapshotPeriod }
 
 /**
  * ISO週番号から週の開始日（月曜）と終了日（日曜）を計算
@@ -13,71 +20,6 @@ function getWeekDateRange(
   const start = dayjs(`${year}-01-01`).isoWeek(week).startOf('isoWeek')
   const end = start.endOf('isoWeek')
   return { start, end }
-}
-
-/**
- * スナップショット期間を人間が読める形式にフォーマット
- *
- * @param period ランキング期間
- * @param locale 'ja' | 'en'
- * @returns フォーマットされた文字列（スナップショット以外は undefined）
- */
-export function formatSnapshotPeriod(
-  period: ChannelsRankingPeriod,
-  locale: 'ja' | 'en' = 'ja'
-): string | undefined {
-  if (!isSnapshotPeriod(period)) {
-    return undefined
-  }
-
-  const { period: type, target } = parseSnapshotPeriod(period as SnapshotPeriod)
-
-  if (type === 'weekly') {
-    // YYYY-Wxx → 2026年第1週（1/6 ~ 1/12） / Week 1, 2026 (1/6 ~ 1/12)
-    const weekMatch = target.match(/^(\d{4})-W(\d{2})$/)
-    if (weekMatch) {
-      const year = parseInt(weekMatch[1], 10)
-      const week = parseInt(weekMatch[2], 10)
-      const { start, end } = getWeekDateRange(year, week)
-      const startStr = `${start.month() + 1}/${start.date()}`
-      const endStr = `${end.month() + 1}/${end.date()}`
-      const dateRange = `${startStr} ~ ${endStr}`
-
-      return locale === 'ja'
-        ? `${year}年第${week}週（${dateRange}）`
-        : `Week ${week}, ${year} (${dateRange})`
-    }
-  }
-
-  if (type === 'monthly') {
-    // YYYY-MM → 2025年7月 / July 2025
-    const monthMatch = target.match(/^(\d{4})-(\d{2})$/)
-    if (monthMatch) {
-      const year = monthMatch[1]
-      const month = parseInt(monthMatch[2], 10)
-      if (locale === 'ja') {
-        return `${year}年${month}月`
-      } else {
-        const monthNames = [
-          'January',
-          'February',
-          'March',
-          'April',
-          'May',
-          'June',
-          'July',
-          'August',
-          'September',
-          'October',
-          'November',
-          'December'
-        ]
-        return `${monthNames[month - 1]} ${year}`
-      }
-    }
-  }
-
-  return undefined
 }
 
 /**
@@ -131,7 +73,7 @@ export function getPeriodDisplayName(
   globalTranslations: (key: string) => string,
   locale: 'ja' | 'en' = 'ja'
 ): string {
-  const snapshotFormatted = formatSnapshotPeriod(period, locale)
+  const snapshotFormatted = formatSnapshotPeriodUtil(period, locale)
   if (snapshotFormatted) {
     return snapshotFormatted
   }

--- a/web/features/channels-ranking/utils/gallery-params.ts
+++ b/web/features/channels-ranking/utils/gallery-params.ts
@@ -1,34 +1,13 @@
 import { getChannels } from 'apis/youtube/getChannels'
 import { ChannelsRankingPagination } from 'config/constants/Pagination'
 import { ChannelsRankingGalleryProps } from 'features/channels-ranking/components/gallery/ChannelsRankingGallery'
-import { ChannelsRankingPeriod, SnapshotPeriod } from 'types/period'
+import { SnapshotPeriod } from 'types/period'
+import { parseSnapshotPeriod } from 'utils/period/snapshot-period'
 import type { getSupersSummaries } from 'apis/supers/getSupersSummaries'
 import type {
   getSupersSnapshotRanking,
   getSupersSnapshotRankingCount
 } from 'apis/supers-snapshots/getRanking'
-
-/**
- * 期間がスナップショット期間（weekly-xxx or monthly-xxx）かどうかを判定
- */
-export function isSnapshotPeriod(
-  period: ChannelsRankingPeriod
-): period is SnapshotPeriod {
-  return period.startsWith('weekly-') || period.startsWith('monthly-')
-}
-
-/**
- * スナップショット期間をパースしてAPIパラメータを取得
- */
-export function parseSnapshotPeriod(period: SnapshotPeriod): {
-  period: 'weekly' | 'monthly'
-  target: string
-} {
-  if (period.startsWith('weekly-')) {
-    return { period: 'weekly', target: period.slice(7) }
-  }
-  return { period: 'monthly', target: period.slice(8) }
-}
 
 type GetSupersSnapshotRanking = Parameters<typeof getSupersSnapshotRanking>[0]
 export function getSupersSnapshotParams({

--- a/web/features/stream-ranking/components/gallery/StreamRankingGalleryTitle.tsx
+++ b/web/features/stream-ranking/components/gallery/StreamRankingGalleryTitle.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { PropsWithChildren } from 'react'
-import { useTranslations } from 'next-intl'
+import { useLocale, useTranslations } from 'next-intl'
 import PeriodHoverCardFactory from 'components/ranking/hover-card/RankingPeriodHoverCardFactory'
 import {
   RankingTableTitleContainer,
@@ -12,8 +12,12 @@ import { SwitchTabs } from 'components/switch-tabs/SwitchTabs'
 import { StreamRankingDimension } from 'features/stream-ranking/types/stream-ranking.type'
 import { Gender } from 'types/gender'
 import { ChannelsRankingPeriod, StreamRankingPeriod } from 'types/period'
+import {
+  formatSnapshotPeriod,
+  isSnapshotPeriod
+} from 'utils/period/snapshot-period'
 
-/** Live → Channels 遷移時の period フォールバック */
+/** Live → Channels 遷移時の period マッピング */
 function getChannelsPeriodFromStreamPeriod(
   period: StreamRankingPeriod
 ): ChannelsRankingPeriod {
@@ -45,12 +49,19 @@ export default function StreamRankingGalleryTitle({
   date,
   className
 }: Props) {
+  const locale = useLocale() as 'ja' | 'en'
   const global = useTranslations('Global')
   const feat = useTranslations('Features.streamRanking')
   const page = useTranslations('Page.ranking.live')
   const t = useTranslations('Components.ranking.aggregationSwitch')
-  const periodName = global(`period.${period}`)
-  const periodKeyword = global(`periodKeyword.${period}`)
+
+  // スナップショット期間の場合はフォーマット、それ以外は翻訳キーを使用
+  const periodName = isSnapshotPeriod(period)
+    ? (formatSnapshotPeriod(period, locale) ?? period)
+    : global(`period.${period}`)
+  const periodKeyword = isSnapshotPeriod(period)
+    ? periodName
+    : global(`periodKeyword.${period}`)
   const periodInParens = period === 'realtime' ? '' : ` (${periodName})`
   const title = feat(`ranking.ui.${dimension}`, {
     period: periodName,

--- a/web/features/stream-ranking/utils/createGetStreamsParams.ts
+++ b/web/features/stream-ranking/utils/createGetStreamsParams.ts
@@ -1,5 +1,9 @@
 import { StreamRankingPagination } from 'config/constants/Pagination'
 import { getStartOf } from 'utils/period/ranking'
+import {
+  getSnapshotDateRange,
+  isSnapshotPeriod
+} from 'utils/period/snapshot-period'
 import type { getStreams } from 'apis/youtube/getStreams'
 import type { StreamRankingGalleryProps } from 'features/stream-ranking/components/gallery/StreamRankingGallery'
 
@@ -15,6 +19,15 @@ export default function createGetStreamsParams({
 
   if (period === 'realtime') {
     result = { ...result, status: 'live', revalidate: 600 }
+  } else if (isSnapshotPeriod(period)) {
+    // 週間/月間スナップショット期間の場合
+    const { start, end } = getSnapshotDateRange(period)
+    result = {
+      ...result,
+      status: 'ended',
+      endedAfter: start,
+      endedBefore: end
+    }
   }
   // TODO: 本当はliveもふくめたい
   else {

--- a/web/features/stream-ranking/utils/createGetSupersBundlesParams.ts
+++ b/web/features/stream-ranking/utils/createGetSupersBundlesParams.ts
@@ -1,5 +1,9 @@
 import { StreamRankingPagination } from 'config/constants/Pagination'
 import { getStartOf } from 'utils/period/ranking'
+import {
+  getSnapshotDateRange,
+  isSnapshotPeriod
+} from 'utils/period/snapshot-period'
 import type { getSupersBundles } from 'apis/supers/getSupersBundles'
 import type { StreamRankingGalleryProps } from 'features/stream-ranking/components/gallery/StreamRankingGallery'
 
@@ -18,6 +22,10 @@ export default function createGetSupersBundlesParams({
   if (period === 'realtime') {
     // NULL means "live now"
     result = { ...result, actualEndTimeGTE: null, actualEndTimeLTE: null }
+  } else if (isSnapshotPeriod(period)) {
+    // 週間/月間スナップショット期間の場合
+    const { start, end } = getSnapshotDateRange(period)
+    result = { ...result, createdAtGTE: start, createdAtLTE: end }
   } else {
     // それ以外は「CreatedAt」基準で取得
     result = { ...result, createdAtGTE: getStartOf(period).toDate() }

--- a/web/types/period.d.ts
+++ b/web/types/period.d.ts
@@ -46,10 +46,13 @@ export type SnapshotPeriod = WeeklySnapshotPeriod | MonthlySnapshotPeriod
 export type ChannelsRankingPeriod = Period | SnapshotPeriod
 
 /**
- * 同接数ランキング
+ * 同接数ランキング / ライブ集計ランキング
  *
  * 「realtime」が追加される
  * またUI上では今年、今週などは表示されないがロジック的には動くので
  * ここの型定義には含めている
+ *
+ * スナップショット期間（週間・月間）もサポート
+ * チャンネル集計ページからの SwitchTabs 遷移でフォールバックせず表示するため
  **/
-export type StreamRankingPeriod = 'realtime' | Period
+export type StreamRankingPeriod = 'realtime' | Period | SnapshotPeriod

--- a/web/utils/metadata/metadata-generator.ts
+++ b/web/utils/metadata/metadata-generator.ts
@@ -1,8 +1,6 @@
 import { Metadata } from 'next'
 import { Locale } from 'next-intl'
 import { getTranslations } from 'next-intl/server'
-import { formatSnapshotPeriod } from 'features/channels-ranking/utils/formatSnapshotPeriod'
-import { isSnapshotPeriod } from 'features/channels-ranking/utils/gallery-params'
 import { Dimension } from 'types/dimension'
 import { Gender } from 'types/gender'
 import {
@@ -11,6 +9,10 @@ import {
   StreamRankingPeriod,
   TopFansPeriod
 } from 'types/period'
+import {
+  formatSnapshotPeriod,
+  isSnapshotPeriod
+} from 'utils/period/snapshot-period'
 
 type Args = {
   locale: Locale

--- a/web/utils/period/snapshot-period.ts
+++ b/web/utils/period/snapshot-period.ts
@@ -1,0 +1,121 @@
+import dayjs from 'lib/dayjs'
+import { SnapshotPeriod } from 'types/period'
+
+/**
+ * 期間がスナップショット期間（weekly-xxx or monthly-xxx）かどうかを判定
+ */
+export function isSnapshotPeriod(period: string): period is SnapshotPeriod {
+  return period.startsWith('weekly-') || period.startsWith('monthly-')
+}
+
+/**
+ * スナップショット期間をパースしてAPIパラメータを取得
+ */
+export function parseSnapshotPeriod(period: SnapshotPeriod): {
+  period: 'weekly' | 'monthly'
+  target: string
+} {
+  if (period.startsWith('weekly-')) {
+    return { period: 'weekly', target: period.slice(7) }
+  }
+  return { period: 'monthly', target: period.slice(8) }
+}
+
+/**
+ * スナップショット期間から日付範囲を取得（JST ベース）
+ */
+export function getSnapshotDateRange(period: SnapshotPeriod): {
+  start: Date
+  end: Date
+} {
+  const { period: type, target } = parseSnapshotPeriod(period)
+
+  if (type === 'weekly') {
+    const weekMatch = target.match(/^(\d{4})-W(\d{2})$/)
+    if (!weekMatch) throw new Error(`Invalid weekly period: ${period}`)
+    const year = parseInt(weekMatch[1], 10)
+    const week = parseInt(weekMatch[2], 10)
+    const start = dayjs(`${year}-01-01`)
+      .tz('Asia/Tokyo')
+      .isoWeek(week)
+      .startOf('isoWeek')
+    const end = start.endOf('isoWeek')
+    return { start: start.toDate(), end: end.toDate() }
+  }
+
+  if (type === 'monthly') {
+    const monthMatch = target.match(/^(\d{4})-(\d{2})$/)
+    if (!monthMatch) throw new Error(`Invalid monthly period: ${period}`)
+    const year = parseInt(monthMatch[1], 10)
+    const month = parseInt(monthMatch[2], 10) - 1
+    const start = dayjs()
+      .tz('Asia/Tokyo')
+      .year(year)
+      .month(month)
+      .startOf('month')
+    const end = start.endOf('month')
+    return { start: start.toDate(), end: end.toDate() }
+  }
+
+  throw new Error(`Unknown period type: ${type}`)
+}
+
+/**
+ * スナップショット期間を人間が読める形式にフォーマット
+ * 非スナップショット期間の場合は undefined を返す
+ */
+export function formatSnapshotPeriod(
+  period: string,
+  locale: 'ja' | 'en'
+): string | undefined {
+  if (!isSnapshotPeriod(period)) {
+    return undefined
+  }
+
+  const { period: type, target } = parseSnapshotPeriod(period)
+
+  if (type === 'weekly') {
+    const weekMatch = target.match(/^(\d{4})-W(\d{2})$/)
+    if (weekMatch) {
+      const year = parseInt(weekMatch[1], 10)
+      const week = parseInt(weekMatch[2], 10)
+      const start = dayjs(`${year}-01-01`).isoWeek(week).startOf('isoWeek')
+      const end = start.endOf('isoWeek')
+      const startStr = `${start.month() + 1}/${start.date()}`
+      const endStr = `${end.month() + 1}/${end.date()}`
+      const dateRange = `${startStr} ~ ${endStr}`
+      return locale === 'ja'
+        ? `${year}年第${week}週（${dateRange}）`
+        : `Week ${week}, ${year} (${dateRange})`
+    }
+  }
+
+  if (type === 'monthly') {
+    const monthMatch = target.match(/^(\d{4})-(\d{2})$/)
+    if (monthMatch) {
+      const year = monthMatch[1]
+      const month = parseInt(monthMatch[2], 10)
+      if (locale === 'ja') {
+        return `${year}年${month}月`
+      } else {
+        const monthNames = [
+          'January',
+          'February',
+          'March',
+          'April',
+          'May',
+          'June',
+          'July',
+          'August',
+          'September',
+          'October',
+          'November',
+          'December'
+        ]
+        return `${monthNames[month - 1]} ${year}`
+      }
+    }
+  }
+
+  return period
+}


### PR DESCRIPTION
## Summary
- `StreamRankingPeriod` 型に `SnapshotPeriod` を追加し、ライブ集計ページで週間/月間ランキングを表示可能に
- スナップショット期間ユーティリティを `utils/period/snapshot-period.ts` に集約してコードの重複を解消
- チャンネル集計 → ライブ集計の SwitchTabs 遷移時に期間がそのまま引き継がれるように改善

## Test plan
- [x] `/ranking/super-chat/live/all/weekly-2026-W03` にアクセスしてランキングが表示されることを確認
- [x] `/ranking/super-chat/live/all/monthly-2025-12` にアクセスしてランキングが表示されることを確認
- [x] チャンネル集計ページから SwitchTabs で「ライブ集計」に遷移した際、週間/月間期間が維持されることを確認
- [x] 型チェック、Lint、ユニットテストが通ることを確認

closes #2799

🤖 Generated with [Claude Code](https://claude.com/claude-code)