### PR TITLE
fix: ページ遷移時にサイドバーと検索の状態をリセット

### DIFF
--- a/web/components/header/xs/HeaderXSSheet.test.tsx
+++ b/web/components/header/xs/HeaderXSSheet.test.tsx
@@ -39,7 +39,8 @@ vi.mock('next-intl/server', () => ({
 vi.mock('lib/navigation', () => ({
   Link: ({ children, href }: { children: React.ReactNode; href: string }) => (
     <a href={href}>{children}</a>
-  )
+  ),
+  usePathname: () => '/'
 }))
 
 vi.mock('components/sidebar/SignOutButton', () => ({

--- a/web/components/header/xs/HeaderXSSheet.tsx
+++ b/web/components/header/xs/HeaderXSSheet.tsx
@@ -1,18 +1,9 @@
-import { PanelLeftIcon } from 'lucide-react'
 import { getTranslations } from 'next-intl/server'
-import { Button } from '@/components/ui/button'
-import {
-  Sheet,
-  SheetTrigger,
-  SheetContent,
-  SheetHeader,
-  SheetDescription,
-  SheetTitle
-} from '@/components/ui/sheet'
 import SidebarContent from 'components/sidebar/SidebarContent'
 import Image from 'components/styles/Image'
 import { getGroups } from 'hooks/useGroups'
 import { auth } from 'lib/auth'
+import { HeaderXSSheetClient } from './HeaderXSSheetClient'
 
 export default async function HeaderXSSheet() {
   const [session, comp, groups] = await Promise.all([
@@ -64,24 +55,12 @@ export default async function HeaderXSSheet() {
   }
 
   return (
-    <Sheet>
-      <SheetTrigger asChild>
-        <Button size="icon" variant="ghost" className="lg:hidden">
-          <PanelLeftIcon className="h-5 w-5" />
-          <span className="sr-only">Toggle Menu</span>
-        </Button>
-      </SheetTrigger>
-      <SheetContent side="left" className="w-[290px] p-0 pt-1" hideCloseButton>
-        <SheetHeader hidden>
-          <SheetTitle hidden>VCharts</SheetTitle>
-          <SheetDescription hidden></SheetDescription>
-        </SheetHeader>
-        <SidebarContent
-          groups={groupsData}
-          labels={labels}
-          isSignedIn={!!session}
-        />
-      </SheetContent>
-    </Sheet>
+    <HeaderXSSheetClient>
+      <SidebarContent
+        groups={groupsData}
+        labels={labels}
+        isSignedIn={!!session}
+      />
+    </HeaderXSSheetClient>
   )
 }

--- a/web/components/header/xs/HeaderXSSheetClient.tsx
+++ b/web/components/header/xs/HeaderXSSheetClient.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import { PanelLeftIcon } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  Sheet,
+  SheetTrigger,
+  SheetContent,
+  SheetHeader,
+  SheetDescription,
+  SheetTitle
+} from '@/components/ui/sheet'
+import { usePathname } from 'lib/navigation'
+
+type Props = {
+  children: ReactNode
+}
+
+export function HeaderXSSheetClient({ children }: Props) {
+  const pathname = usePathname()
+
+  // pathnameをkeyに使うことで、パス変更時にSheetがリマウントされ閉じた状態に戻る
+  return (
+    <Sheet key={pathname}>
+      <SheetTrigger asChild>
+        <Button size="icon" variant="ghost" className="lg:hidden">
+          <PanelLeftIcon className="h-5 w-5" />
+          <span className="sr-only">Toggle Menu</span>
+        </Button>
+      </SheetTrigger>
+      <SheetContent side="left" className="w-[290px] p-0 pt-1" hideCloseButton>
+        <SheetHeader hidden>
+          <SheetTitle hidden>VCharts</SheetTitle>
+          <SheetDescription hidden></SheetDescription>
+        </SheetHeader>
+        {children}
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/web/components/talent-search/components/TalentSearch.tsx
+++ b/web/components/talent-search/components/TalentSearch.tsx
@@ -13,7 +13,7 @@ import {
 } from '@/components/ui/command'
 import { cn } from '@/lib/utils'
 import { ChannelsSchema } from 'apis/youtube/schema/channelSchema'
-import { Link } from 'lib/navigation'
+import { Link, usePathname } from 'lib/navigation'
 import { searchTalents } from '../actions/searchTalentsActions'
 
 type Props = {
@@ -27,6 +27,13 @@ export function TalentSearch({ className, dropdown }: Props) {
   const [talents, setTalents] = React.useState<ChannelsSchema>([])
   const [loading, setLoading] = React.useState(false)
   const queryIsLongEnough = debouncedQuery.length >= 2
+  const pathname = usePathname()
+
+  // パス変更時に状態をリセット
+  React.useEffect(() => {
+    setQuery('')
+    setTalents([])
+  }, [pathname])
 
   React.useEffect(() => {
     const fetchTalents = async () => {


### PR DESCRIPTION
## Summary
- ページ遷移時にHeaderXSSheet（スマホサイドバー）が開いたままになる問題を修正
- ページ遷移時にTalentSearch（検索）の入力と結果が残る問題を修正
- `usePathname`でパス変更を検知して状態をリセット

## Test plan
- [x] スマホサイズでサイドバーを開き、リンクをタップして遷移後にサイドバーが閉じることを確認
- [x] 検索で結果を表示し、結果をタップして遷移後に検索欄がクリアされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)