### PR TITLE
fix: last1Year を thisYear にリダイレクト

### DIFF
--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -42,6 +42,12 @@ const nextConfig: NextConfig = {
         destination: '/:locale/ranking/:dimension/live/:group/thisYear',
         permanent: true
       },
+      // 2025/01/25: Redirect last1Year to thisYear for live ranking
+      {
+        source: '/:locale/ranking/:dimension/live/:group/last1Year',
+        destination: '/:locale/ranking/:dimension/live/:group/thisYear',
+        permanent: true
+      },
       // 2025/06/12: Modify period 'all' to 'wholePeriod'
       {
         source: '/:locale/ranking/:dimension/live/:group/all',


### PR DESCRIPTION
## Summary
- 検索エンジン（Bingbot等）がインデックスしている古いURL `last1Year` へのアクセスを `thisYear` にリダイレクト

## Background
`/ja/ranking/concurrent-viewer/live/independent/last1Year` などの古いURLにbingbotがアクセスして404を返していた。

## Test plan
- [ ] `/ja/ranking/concurrent-viewer/live/independent/last1Year` が301で `thisYear` にリダイレクトされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)