### PR TITLE
fix: グループロゴ画像に長期キャッシュを設定

### DIFF
--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -14,6 +14,17 @@ const nextConfig: NextConfig = {
   },
   async headers() {
     return [
+      // グループロゴ画像の長期キャッシュ（1年間）
+      // ロゴはほとんど変わらないので、ブラウザキャッシュで完結させる
+      {
+        source: '/group/:groupId/logo.:ext(png|webp)',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, max-age=31536000, immutable'
+          }
+        ]
+      },
       // workaround: browser --> PWA google auth causes error
       // https://intercom.help/progressier/en/articles/9519381-google-oauth2-is-not-working-in-my-pwa-on-ios-why
       // https://stackoverflow.com/questions/62127764/google-oauth2-invalid-token-format-error-on-redirecting-to-pwa


### PR DESCRIPTION
## Summary
- グループロゴ画像（`/group/*/logo.png|webp`）に `Cache-Control: public, max-age=31536000, immutable` を設定
- ブラウザキャッシュで完結し、1年間リクエストが飛ばなくなる

## Test plan
- [ ] デプロイ後、グループロゴ画像のレスポンスヘッダーを確認
- [ ] `cache-control: public, max-age=31536000, immutable` が返ることを確認

Closes #2832

🤖 Generated with [Claude Code](https://claude.com/claude-code)