### PR TITLE
fix: フッターの同接数ランキングリンクを修正

### DIFF
--- a/web/components/footer/Footer.tsx
+++ b/web/components/footer/Footer.tsx
@@ -41,16 +41,16 @@ export function Footer() {
           href: '/ranking/concurrent-viewer/live/all/realtime'
         },
         {
-          label: t('last24Hours'),
-          href: '/ranking/concurrent-viewer/live/all/last24Hours'
-        },
-        {
-          label: t('last7Days'),
-          href: '/ranking/concurrent-viewer/live/all/last7Days'
-        },
-        {
           label: t('last30Days'),
           href: '/ranking/concurrent-viewer/live/all/last30Days'
+        },
+        {
+          label: t('thisYear'),
+          href: '/ranking/concurrent-viewer/live/all/thisYear'
+        },
+        {
+          label: t('weeklyMonthlyRankings'),
+          href: '/ranking/concurrent-viewer/live'
         }
       ]
     },


### PR DESCRIPTION
## Summary
- フッターの同接数ランキングリンクを「リアルタイム」「過去30日間」「今年」「週間・月間ランキング」の4つに変更

Closes #2821

## Test plan
- [x] フッターの同接数ランキングセクションに4つのリンクが表示されることを確認
- [x] 各リンクが正しいページに遷移することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)