### PR TITLE
feat: 週間スパチャランキングのブログ記事ページを追加

### DIFF
--- a/web/app/[locale]/(end-user)/(default)/blog/2026/weekly/w04/page.tsx
+++ b/web/app/[locale]/(end-user)/(default)/blog/2026/weekly/w04/page.tsx
@@ -16,7 +16,7 @@ type Props = {
 }
 
 export async function generateMetadata(): Promise<Metadata> {
-  const title = `VTuberスパチャ週間ランキング TOP10【${YEAR}年 ${WEEK_DISPLAY}】`
+  const title = `VTuberスパチャランキング 週間TOP10【${YEAR}年 ${WEEK_DISPLAY}】`
   const description = `${YEAR}年${WEEK_DISPLAY}（${DATE_RANGE}）のVTuberスーパーチャットランキングTOP10を発表。今週最もスパチャを集めたVTuberは誰？`
 
   const ogImageUrl = `${getWebUrl()}/api/og/weekly-ranking?week=${WEEK}&group=all`


### PR DESCRIPTION
## Summary
- Google Discover からのトラフィック獲得を目的として、週間スーパーチャットランキングを記事形式で公開するページを追加
- `/blog/2026/weekly/w04` に第4週のランキング記事を作成
- OGP画像は既存の週間ランキングOGPを使用（1200x630px、Discover要件を満たす）

## 変更内容
- `max-image-preview: large` を設定（Discover対応）
- 今週のハイライトセクションを追加
- 将来の月間ランキング追加を見据えたURL構造（`/blog/[year]/weekly/[week]`）

## 関連Issue
Closes #2770

## Test plan
- [x] `/ja/blog/2026/weekly/w04` でページが正常に表示される
- [x] OGP画像が正しく設定されている（デベロッパーツールで確認）
- [x] ランキングTOP10が正しく表示される
- [x] 各チャンネルへのリンクが機能する

🤖 Generated with [Claude Code](https://claude.com/claude-code)