### PR TITLE
feat: ブログ記事に公開日時を表示

### DIFF
--- a/web/app/[locale]/(end-user)/(default)/blog/2026/weekly/w04/page.tsx
+++ b/web/app/[locale]/(end-user)/(default)/blog/2026/weekly/w04/page.tsx
@@ -77,8 +77,8 @@ export default async function WeeklySuperchatRankingW04(props: Props) {
           <h1 className="text-2xl sm:text-3xl font-bold leading-tight">
             VTuberスパチャランキング 週間TOP10【{YEAR}年 {WEEK_DISPLAY}】
           </h1>
-          <time dateTime={PUBLISHED_AT} className="block text-sm">
-            {PUBLISHED_DATE_DISPLAY}
+          <time dateTime={PUBLISHED_AT} className="block">
+            公開日時：{PUBLISHED_DATE_DISPLAY} (日本時間)
           </time>
           <p className="text-muted-foreground">
             {YEAR}年{WEEK_DISPLAY}（{DATE_RANGE}）


### PR DESCRIPTION
## Summary
- Google News ガイドラインに従い、見出しと本文の間に明確な日付を表示
- `<time>` 要素で公開日時をマークアップ
- メタデータの `publishedTime` と表示を一貫させる

## 変更内容
```tsx
<h1>タイトル</h1>
<time dateTime="2026-01-26T20:01:00+09:00">
  2026年1月26日 20:01
</time>
<p>本文...</p>
```

## Test plan
- [x] 公開日時が見出しの直下に表示される
- [x] `<time>` 要素の `dateTime` 属性が正しい

🤖 Generated with [Claude Code](https://claude.com/claude-code)