### PR TITLE
feat: スパチャランキングの canonical を検索ニーズに合わせて調整

### DIFF
--- a/web/app/[locale]/(end-user)/(default)/ranking/[dimension]/channels/[group]/[period]/page.tsx
+++ b/web/app/[locale]/(end-user)/(default)/ranking/[dimension]/channels/[group]/[period]/page.tsx
@@ -83,17 +83,27 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
         ]
       }
     }),
-    /** 2025/05/01：period, gender, pageは区別しないcanonicalにしてみる */
+    /** 2025/05/01：period, gender, pageは区別しないcanonicalにしてみる（last24Hoursは独立） */
     alternates: getAlternates({
-      pathname: `/ranking/${dimension}/channels/${groupId}/${dimension === 'subscriber' ? 'wholePeriod' : 'last30Days'}`,
+      pathname: `/ranking/${dimension}/channels/${groupId}/${getCanonicalPeriod(dimension, period)}`,
       locale
     })
   }
 }
 
-/** dimension ごとの canonical period を取得 */
-function getCanonicalPeriod(dimension: ChannelsRankingDimension): string {
-  return dimension === 'subscriber' ? 'wholePeriod' : 'last30Days'
+/** dimension と period から canonical period を取得 */
+function getCanonicalPeriod(
+  dimension: ChannelsRankingDimension,
+  period: ChannelsRankingPeriod
+): string {
+  if (dimension === 'subscriber') {
+    return 'wholePeriod'
+  }
+  // super-chat の場合: last24Hours は独立した canonical
+  if (period === 'last24Hours') {
+    return 'last24Hours'
+  }
+  return 'last30Days'
 }
 
 /** dimension の表示名を取得 */
@@ -129,7 +139,7 @@ export default async function RankingChannelsPage(props: Props) {
     localeTyped
   )
 
-  const canonicalPeriod = getCanonicalPeriod(dimension)
+  const canonicalPeriod = getCanonicalPeriod(dimension, period)
 
   // super-chat dimension の場合、ハブページ情報を構築
   let hubPage: { name: string; href: string } | undefined

--- a/web/app/[locale]/(end-user)/(default)/ranking/[dimension]/live/[group]/[period]/page.tsx
+++ b/web/app/[locale]/(end-user)/(default)/ranking/[dimension]/live/[group]/[period]/page.tsx
@@ -31,9 +31,8 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
     errorContext: 'live ranking page (metadata)'
   })
 
-  // canonical period: concurrent-viewer は realtime、super-chat は last30Days
-  const canonicalPeriod =
-    dimension === 'concurrent-viewer' ? 'realtime' : 'last30Days'
+  // canonical period を取得
+  const canonicalPeriod = getCanonicalPeriod(dimension, period)
 
   return {
     ...(await generateTitleAndDescription({
@@ -53,9 +52,19 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
   }
 }
 
-/** dimension ごとの canonical period を取得 */
-function getCanonicalPeriod(dimension: StreamRankingDimension): string {
-  return dimension === 'concurrent-viewer' ? 'realtime' : 'last30Days'
+/** dimension と period から canonical period を取得 */
+function getCanonicalPeriod(
+  dimension: StreamRankingDimension,
+  period: StreamRankingPeriod
+): string {
+  if (dimension === 'concurrent-viewer') {
+    return 'realtime'
+  }
+  // super-chat の場合: realtime, last24Hours は独立した canonical
+  if (period === 'realtime' || period === 'last24Hours') {
+    return period
+  }
+  return 'last30Days'
 }
 
 /** dimension の表示名を取得 */
@@ -91,7 +100,7 @@ export default async function RankingLivePage(props: Props) {
     localeTyped
   )
 
-  const canonicalPeriod = getCanonicalPeriod(dimension)
+  const canonicalPeriod = getCanonicalPeriod(dimension, period)
 
   // ハブページ情報を構築
   let hubPage: { name: string; href: string } | undefined


### PR DESCRIPTION
## Summary
- スパチャランキング（チャンネル集計）: `last24Hours` を独立した canonical URL に変更
- スパチャランキング（ライブ集計）: `realtime`, `last24Hours` を独立した canonical URL に変更
- 検索ワード「スパチャ ランキング リアルタイム」「スパチャ ランキング 今日」に対応

## Test plan
- [x] `/ranking/super-chat/channels/:group/last24Hours` が自身を canonical として出力すること
- [x] `/ranking/super-chat/live/:group/realtime` が自身を canonical として出力すること
- [x] `/ranking/super-chat/live/:group/last24Hours` が自身を canonical として出力すること
- [x] その他の期間（`last30Days` など）は従来通り `last30Days` を canonical として出力すること

Closes #2838

🤖 Generated with [Claude Code](https://claude.com/claude-code)