### PR TITLE
fix: チケットページに未認証時のリダイレクトを追加

### DIFF
--- a/web/app/[locale]/(authenticated)/dashboard/tickets/page.tsx
+++ b/web/app/[locale]/(authenticated)/dashboard/tickets/page.tsx
@@ -3,6 +3,8 @@ import { Metadata } from 'next'
 import { getTranslations } from 'next-intl/server'
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
+import { auth } from 'lib/auth'
+import { redirect } from 'lib/navigation'
 import TicketSummary from './_components/TicketSummary'
 import TicketUsageHistory from './_components/TicketUsageHistory'
 
@@ -55,7 +57,19 @@ function TicketUsageHistorySkeleton() {
   )
 }
 
-export default async function TicketsPage() {
+type Props = {
+  params: Promise<{ locale: string }>
+}
+
+export default async function TicketsPage(props: Props) {
+  const session = await auth()
+  const locale = (await props.params).locale
+
+  if (!session) {
+    redirect({ href: '/auth/signin', locale: locale as 'ja' | 'en' })
+    return
+  }
+
   const t = await getTranslations('Page.dashboard.tickets')
 
   return (


### PR DESCRIPTION
## Summary
- `/dashboard/tickets` ページに未認証ユーザーのリダイレクト処理を追加
- `/dashboard` ページと同じパターンで `auth()` によるセッションチェックを実装

## Test plan
- [x] 未ログイン状態で `/dashboard/tickets` にアクセスし、`/auth/signin` にリダイレクトされることを確認
- [x] ログイン状態で `/dashboard/tickets` に正常にアクセスできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)