### PR TITLE
chore: dependabot に eslint グループを追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,14 @@ updates:
       time: '11:55'
       timezone: 'Asia/Tokyo'
     groups:
+      eslint:
+        patterns:
+          - 'eslint'
+          - '@eslint/*'
+          - 'typescript-eslint'
+          - '@typescript-eslint/*'
+          - 'eslint-config-next'
+          - 'eslint-plugin-*'
       storybook:
         patterns:
           - 'storybook'


### PR DESCRIPTION
## Summary
- eslint 関連パッケージ（`eslint`, `@eslint/*`, `typescript-eslint`, `@typescript-eslint/*`, `eslint-config-next`, `eslint-plugin-*`）を dependabot のグループに追加
- PR #2913 のような peer dependency 不整合を防止

## 背景
- `@eslint/js` が単独で v10 にバンプされ、`eslint@^10.0.0` を要求するが `eslint` 本体は v9 のままで CI 失敗（#2913）
- グループ化により関連パッケージがまとめてバンプされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)