### PR TITLE
chore: backend にも eslint グループを追加し web 側のパターンを拡充

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,8 +27,9 @@ updates:
           - '@eslint/*'
           - 'typescript-eslint'
           - '@typescript-eslint/*'
-          - 'eslint-config-next'
+          - 'eslint-config-*'
           - 'eslint-plugin-*'
+          - 'eslint-import-resolver-*'
       storybook:
         patterns:
           - 'storybook'
@@ -49,6 +50,15 @@ updates:
       time: '11:55'
       timezone: 'Asia/Tokyo'
     groups:
+      eslint:
+        patterns:
+          - 'eslint'
+          - '@eslint/*'
+          - 'typescript-eslint'
+          - '@typescript-eslint/*'
+          - 'eslint-config-*'
+          - 'eslint-plugin-*'
+          - 'eslint-import-resolver-*'
       opentelemetry:
         patterns:
           - '@opentelemetry/*'


### PR DESCRIPTION
## Summary
- backend の dependabot 設定に eslint グループを追加
- web 側の eslint グループに `eslint-import-resolver-*` と `eslint-config-*`（`eslint-config-next` → ワイルドカード）を追加し統一

## 背景
- #2957 で `eslint@10` が単独バンプされ `eslint-plugin-import-x` の peer dependency 不整合で CI 失敗
- #2958 で web 側のグループ化は対応済み。本 PR で backend 側も同様に対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)