### PR TITLE
style: 登録者成長率ランキングOGPのデザイン改善

### DIFF
--- a/backend/apps/closed-api-server/src/presentation/x/x-subscriber-growth.scenario.ts
+++ b/backend/apps/closed-api-server/src/presentation/x/x-subscriber-growth.scenario.ts
@@ -156,12 +156,11 @@ export class XSubscriberGrowthScenario {
     )
 
     const lines = [
-      `📈${period}VTuber登録者成長率ランキング`,
+      `📈${period}チャンネル成長率ランキング`,
       '',
-      `YouTubeチャンネルTOP5`,
       ...rankingLines,
       '',
-      'TOP40は画像でチェック'
+      '登録者数成長率TOP40は画像にて掲載中'
     ]
 
     return lines.join('\n')

--- a/web/app/api/og/monthly-subscriber-growth/route.tsx
+++ b/web/app/api/og/monthly-subscriber-growth/route.tsx
@@ -110,11 +110,22 @@ function RankingRow({
         style={{
           display: 'flex',
           width: 44,
+          height: 44,
           fontSize: 26,
           fontWeight: 'bold',
           justifyContent: 'center',
+          alignItems: 'center',
           flexShrink: 0,
-          color: '#333'
+          borderRadius: 8,
+          color: item.rank <= 3 ? 'white' : '#333',
+          background:
+            item.rank === 1
+              ? '#b8860b'
+              : item.rank === 2
+                ? '#8a8a8a'
+                : item.rank === 3
+                  ? '#b45309'
+                  : 'transparent'
         }}
       >
         {item.rank}
@@ -280,7 +291,7 @@ function ColumnHeader() {
         display: 'flex',
         alignItems: 'center',
         padding: '0 12px',
-        background: '#1a202c',
+        background: '#e11d48',
         color: 'white',
         height: 40,
         fontSize: 15,
@@ -372,19 +383,19 @@ export async function GET() {
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'flex-start',
-          padding: '15px 24px 15px',
+          padding: '16px 24px',
           gap: 32
         }}
       >
         <div
           style={{
-            fontSize: 46,
+            fontSize: 44,
             fontWeight: 'bold',
             color: '#1a202c',
             display: 'flex'
           }}
         >
-          月間YouTube登録者成長率ランキングTOP40
+          チャンネル登録者数成長率ランキングTOP40
         </div>
         <div
           style={{

--- a/web/app/api/og/weekly-subscriber-growth/route.tsx
+++ b/web/app/api/og/weekly-subscriber-growth/route.tsx
@@ -117,11 +117,22 @@ function RankingRow({
         style={{
           display: 'flex',
           width: 44,
+          height: 44,
           fontSize: 26,
           fontWeight: 'bold',
           justifyContent: 'center',
+          alignItems: 'center',
           flexShrink: 0,
-          color: '#333'
+          borderRadius: 8,
+          color: item.rank <= 3 ? 'white' : '#333',
+          background:
+            item.rank === 1
+              ? '#b8860b'
+              : item.rank === 2
+                ? '#8a8a8a'
+                : item.rank === 3
+                  ? '#b45309'
+                  : 'transparent'
         }}
       >
         {item.rank}
@@ -287,7 +298,7 @@ function ColumnHeader() {
         display: 'flex',
         alignItems: 'center',
         padding: '0 12px',
-        background: '#1a202c',
+        background: '#e11d48',
         color: 'white',
         height: 40,
         fontSize: 15,
@@ -379,19 +390,19 @@ export async function GET() {
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'flex-start',
-          padding: '15px 24px 15px',
+          padding: '16px 24px',
           gap: 32
         }}
       >
         <div
           style={{
-            fontSize: 46,
+            fontSize: 44,
             fontWeight: 'bold',
             color: '#1a202c',
             display: 'flex'
           }}
         >
-          週間YouTube登録者成長率ランキングTOP40
+          チャンネル登録者数成長率ランキングTOP40
         </div>
         <div
           style={{


### PR DESCRIPTION
## Summary
- 週間・月間ランキングOGPの1〜3位に金・銀・銅の背景色バッジを追加
- カラムヘッダーの背景色をrose-600（#e11d48）に変更
- Xポストのメッセージ文言を改善

## Test plan
- [x] `/api/og/weekly-subscriber-growth` でOGP画像を確認
- [x] `/api/og/monthly-subscriber-growth` でOGP画像を確認
- [x] 1〜3位のバッジ色（金・銀・銅）が正しく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)