### PR TITLE
fix: チャンネル登録フォームの性別が連続申請時にリセットされないバグを修正

### DIFF
--- a/web/app/[locale]/(end-user)/(default)/channels/add/_components/form/RegistrationForm.tsx
+++ b/web/app/[locale]/(end-user)/(default)/channels/add/_components/form/RegistrationForm.tsx
@@ -183,7 +183,7 @@ export function RegistrationForm({ groups }: RegistrationFormProps) {
                   <FormControl>
                     <RadioGroup
                       onValueChange={field.onChange}
-                      defaultValue={field.value}
+                      value={field.value}
                       className="flex space-x-4"
                     >
                       <FormItem className="flex items-center space-x-2 space-y-0">


### PR DESCRIPTION
## Summary
- チャンネル登録フォーム(/channels/add)で連続申請すると、2回目以降の性別が選択によらず常に「女性」で送信されるバグを修正
- `RadioGroup` の `defaultValue` を `value` に変更し、`form.reset()` 後もフォーム状態と UI が同期するようにした

## 原因
`RadioGroup` に `defaultValue` を使用していたため、初回マウント時のみ値が反映され、`form.reset()` による状態変更が RadioGroup の内部状態に伝播しなかった

## Test plan
- [ ] /channels/add でチャンネルを申請後、続けて別のチャンネルを「男性」で申請し、正しく男性として送信されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)