### PR TITLE
feat: Google AdSense自動広告を有効化

### DIFF
--- a/web/app/[locale]/layout.tsx
+++ b/web/app/[locale]/layout.tsx
@@ -10,6 +10,7 @@ import NextTopLoader from 'nextjs-toploader'
 import { Toaster } from '@/components/ui/sonner'
 import { SessionKeepAlive } from 'components/auth/session/SessionKeepAlive'
 import { HyperChatTicketProgress } from 'components/hyper-chat/progress/HyperChatTicketProgress'
+import { AdsByGoogleScript } from 'components/script/AdsByGoogleScript'
 import { ClarityScript } from 'components/script/ClarityScript'
 import { SidebarProvider } from 'components/sidebar/SidebarContext'
 import { ThemeProvider } from 'components/styles/ThemeProvider'
@@ -102,7 +103,7 @@ export default async function LocaleLayout(props: Props) {
         </ThemeProvider>
 
         {/* Google AdSense */}
-        {/* <AdsByGoogleScript strategy="beforeInteractive" /> */}
+        <AdsByGoogleScript strategy="afterInteractive" />
       </body>
     </html>
   )

--- a/web/components/script/AdsByGoogleScript.tsx
+++ b/web/components/script/AdsByGoogleScript.tsx
@@ -1,6 +1,5 @@
 import Script, { type ScriptProps } from 'next/script'
 
-/** @deprecated Adsense使わないので削除してもいいかも */
 export const AdsByGoogleScript: React.FC<ScriptProps> = (
   props: ScriptProps
 ) => {


### PR DESCRIPTION
## Summary
- `AdsByGoogleScript` コンポーネントの `@deprecated` コメントを削除
- `layout.tsx` でコメントアウトされていた自動広告スクリプトを有効化
- `strategy` を `beforeInteractive` から `afterInteractive` に変更（ページ解析のブロックを防ぐ）

## Test plan
- [ ] 本番環境（`ENV_NAME=production`）でのみ広告スクリプトが読み込まれることを確認
- [x] 開発環境では広告スクリプトが読み込まれないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)