### PR TITLE
perf: 配信詳細ページのキャッシュ改善と通信量削減

### DIFF
--- a/web/apis/supers/getSupersBundle.ts
+++ b/web/apis/supers/getSupersBundle.ts
@@ -2,12 +2,14 @@ import {
   SupersBundleSchema,
   schema
 } from 'apis/youtube/schema/supersBundleSchema'
-import { fetchAPI } from 'lib/fetchAPI'
+import { CACHE_1H, fetchAPI } from 'lib/fetchAPI'
 
 export async function getSupersBundle(
   videoId: string
 ): Promise<SupersBundleSchema | undefined> {
-  const res = await fetchAPI(`/api/supers-bundles/${videoId}`)
+  const res = await fetchAPI(`/api/supers-bundles/${videoId}`, {
+    next: { revalidate: CACHE_1H }
+  })
   if (!res.ok) {
     throw new Error(`Failed to fetch data: ${await res.text()}`)
   }

--- a/web/app/[locale]/(end-user)/(no-layout)/youtube/live/[videoId]/_components/template/LiveIdTemplate.tsx
+++ b/web/app/[locale]/(end-user)/(no-layout)/youtube/live/[videoId]/_components/template/LiveIdTemplate.tsx
@@ -41,7 +41,7 @@ async function Overview({
 
       <div>
         <Suspense fallback={<StreamGallerySkeleton />}>
-          <EndedStreamGallery where={{ channelId }} showHeader />
+          <EndedStreamGallery where={{ channelId }} showHeader limit={3} />
           <SeeMoreLinkSection channelId={channelId} groupId={stream.group} />
         </Suspense>
       </div>

--- a/web/features/group/ended/components/EndedStreamGallery.tsx
+++ b/web/features/group/ended/components/EndedStreamGallery.tsx
@@ -11,6 +11,7 @@ import StreamGalleryHeader from 'features/group/stream/components/gallery/Stream
 import { StreamGallerySearchParams } from 'features/group/types/stream-gallery'
 
 type Props = StreamGallerySearchParams & {
+  limit?: number
   compact?: boolean
   showHeader?: boolean
   where?: { title?: string; channelId?: string; group?: string }
@@ -18,6 +19,7 @@ type Props = StreamGallerySearchParams & {
 
 export default async function EndedStreamGallery({
   page,
+  limit,
   compact,
   showHeader,
   where
@@ -30,7 +32,7 @@ export default async function EndedStreamGallery({
       group,
       channelId,
       orderBy: [{ field: 'actualEndTime', order: 'desc' }],
-      limit: StreamGalleryPagination.getLimit(compact),
+      limit: limit ?? StreamGalleryPagination.getLimit(compact),
       offset: StreamGalleryPagination.getOffset(page)
     }),
     getTranslations('Features.group.ended'),


### PR DESCRIPTION
## Summary
- `getSupersBundle` のキャッシュ期間をデフォルト60秒から1時間に延長し、リクエスト数を削減
- 配信詳細ページの関連配信ギャラリー表示を12件から3件に制限し、通信量を軽減

## Test plan
- [x] 配信詳細ページ (`/youtube/live/[videoId]`) でスパチャ合計額が正しく表示されること
- [x] 関連配信ギャラリーが3件表示されること
- [x] 他ページの `EndedStreamGallery` 表示件数に影響がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)