### PR TITLE
refactor: RedisキャッシュをインメモリキャッシュJに統一

### DIFF
--- a/backend/apps/closed-api-server/src/cache/cache.module.ts
+++ b/backend/apps/closed-api-server/src/cache/cache.module.ts
@@ -1,13 +1,9 @@
-import KeyvRedis from '@keyv/redis'
 import { CacheModule } from '@nestjs/cache-manager'
 import { ConfigModule, ConfigService } from '@nestjs/config'
 import Keyv from 'keyv'
 
 /**
- * キャッシュモジュールの設定
- *
- * - 本番環境: REDIS_URL が設定されている場合は Redis を使用
- * - ローカル: インメモリキャッシュ（Keyv デフォルト）を使用
+ * キャッシュモジュールの設定（インメモリキャッシュ）
  *
  * 環境ごとにキーのnamespaceを分けることで、キーの重複を防ぐ
  *
@@ -22,15 +18,7 @@ export const AppCacheModule = CacheModule.registerAsync({
   imports: [ConfigModule],
   inject: [ConfigService],
   useFactory: (configService: ConfigService) => {
-    const redisUrl = configService.get<string>('REDIS_URL')
     const namespace = configService.get<string>('ENV_NAME') || 'local'
-
-    if (redisUrl) {
-      return {
-        stores: [new Keyv({ store: new KeyvRedis(redisUrl), namespace })]
-      }
-    }
-
     return {
       stores: [new Keyv({ namespace })]
     }

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,7 +9,6 @@
       "dependencies": {
         "@google-cloud/opentelemetry-cloud-trace-exporter": "^3.0.0",
         "@googleapis/youtube": "^31.0.0",
-        "@keyv/redis": "^5.1.6",
         "@nestjs/cache-manager": "^3.1.0",
         "@nestjs/common": "^11.1.16",
         "@nestjs/config": "^4.0.2",
@@ -2640,23 +2639,6 @@
         "url": "https://opencollective.com/js-sdsl"
       }
     },
-    "node_modules/@keyv/redis": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/@keyv/redis/-/redis-5.1.6.tgz",
-      "integrity": "sha512-eKvW6pspvVaU5dxigaIDZr635/Uw6urTXL3gNbY9WTR8d3QigZQT+r8gxYSEOsw4+1cCBsC4s7T2ptR0WC9LfQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@redis/client": "^5.10.0",
-        "cluster-key-slot": "^1.1.2",
-        "hookified": "^1.13.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "keyv": "^5.6.0"
-      }
-    },
     "node_modules/@keyv/serialize": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
@@ -4270,18 +4252,6 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/@redis/client": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.10.0.tgz",
-      "integrity": "sha512-JXmM4XCoso6C75Mr3lhKA3eNxSzkYi3nCzxDIKY+YOszYsJjuKbFgVtguVPbLMOttN4iu2fXoc2BGhdnYhIOxA==",
-      "license": "MIT",
-      "dependencies": {
-        "cluster-key-slot": "1.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.45",
@@ -7466,15 +7436,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
-      }
-    },
-    "node_modules/cluster-key-slot": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
-      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/co": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "@google-cloud/opentelemetry-cloud-trace-exporter": "^3.0.0",
     "@googleapis/youtube": "^31.0.0",
-    "@keyv/redis": "^5.1.6",
     "@nestjs/cache-manager": "^3.1.0",
     "@nestjs/common": "^11.1.16",
     "@nestjs/config": "^4.0.2",


### PR DESCRIPTION
## Summary

- コスト削減のため Redis Cloud を廃止し、すべての環境でインメモリキャッシュに統一
- `@keyv/redis` パッケージを削除
- `cache.module.ts` から `REDIS_URL` による Redis 分岐ロジックを除去

## 注意事項

本番環境の `REDIS_URL` 環境変数および Redis Cloud サービスは別途手動で削除・解約してください。

## Test plan

- [x] 型チェック通過 (`npm run type-check`)
- [x] Lint 通過 (`npm run lint`)
- [x] ユニットテスト通過 (`npm test`: 89 tests passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)