### PR TITLE
perf: Next.jsデータキャッシュをアグレッシブに延長してVercelコスト削減

### DIFF
--- a/web/apis/channel-statistics/getAggregatedSubscriberCounts.ts
+++ b/web/apis/channel-statistics/getAggregatedSubscriberCounts.ts
@@ -2,7 +2,7 @@ import {
   responseSchema,
   AggregatedSubscriberCountSchema
 } from 'apis/channel-statistics/schema/aggregatedSubscriberCountSchema'
-import { CACHE_1D, fetchAPI } from 'lib/fetchAPI'
+import { CACHE_1W, fetchAPI } from 'lib/fetchAPI'
 
 export async function getAggregatedSubscriberCounts(args: {
   channelId: string
@@ -19,7 +19,7 @@ export async function getAggregatedSubscriberCounts(args: {
 
   const res = await fetchAPI(
     `/api/channel-statistics/subscriber-counts?${params.toString()}`,
-    { next: { revalidate: CACHE_1D } }
+    { next: { revalidate: CACHE_1W } }
   )
 
   if (!res.ok) {

--- a/web/apis/groups/getGroup.ts
+++ b/web/apis/groups/getGroup.ts
@@ -1,12 +1,12 @@
 'use server'
 
 import { GROUPS } from 'apis/tags/revalidate-tags'
-import { fetchAPI } from 'lib/fetchAPI'
+import { CACHE_1W, fetchAPI } from 'lib/fetchAPI'
 import { groupSchema, GroupSchema } from './groupSchema'
 
 export async function getGroup(id: string): Promise<GroupSchema | null> {
   const res = await fetchAPI(`/api/groups/${id}`, {
-    next: { revalidate: 86400, tags: [GROUPS] } // 1日キャッシュ
+    next: { revalidate: CACHE_1W, tags: [GROUPS] }
   })
 
   if (res.status === 404) {

--- a/web/apis/groups/getGroupRegistrations.ts
+++ b/web/apis/groups/getGroupRegistrations.ts
@@ -1,6 +1,6 @@
 'use server'
 
-import { fetchAPI } from 'lib/fetchAPI'
+import { CACHE_1H, fetchAPI } from 'lib/fetchAPI'
 import {
   groupRegistrationsResponseSchema,
   GroupRegistrationsSchema
@@ -15,7 +15,7 @@ export async function getGroupRegistrations(
   }
 
   const res = await fetchAPI(url.toString(), {
-    cache: 'no-store' // 申請履歴は最新の状態を取得
+    next: { revalidate: CACHE_1H }
   })
 
   if (!res.ok) {

--- a/web/apis/groups/getGroups.ts
+++ b/web/apis/groups/getGroups.ts
@@ -1,12 +1,12 @@
 'use server'
 
 import { GROUPS } from 'apis/tags/revalidate-tags'
-import { fetchAPI } from 'lib/fetchAPI'
+import { CACHE_1W, fetchAPI } from 'lib/fetchAPI'
 import { groupsResponseSchema, GroupsSchema } from './groupSchema'
 
 export async function getGroups(): Promise<GroupsSchema> {
   const res = await fetchAPI('/api/groups', {
-    next: { revalidate: 86400, tags: [GROUPS] } // 1日キャッシュ
+    next: { revalidate: CACHE_1W, tags: [GROUPS] }
   })
 
   if (!res.ok) {

--- a/web/apis/hyper-chat-rankings/getPosterRanking.ts
+++ b/web/apis/hyper-chat-rankings/getPosterRanking.ts
@@ -7,7 +7,7 @@ import {
   responseSchema
 } from 'apis/hyper-chat-rankings/posterRankingSchema'
 import { getHyperChatTag } from 'apis/tags/revalidate-tags'
-import { CACHE_1D, fetchAPI } from 'lib/fetchAPI'
+import { CACHE_1W, fetchAPI } from 'lib/fetchAPI'
 
 export async function getPosterRanking(
   channelId: string,
@@ -20,7 +20,7 @@ export async function getPosterRanking(
 
   const res = await fetchAPI(
     `/api/hyper-chat-rankings/channels/${channelId}/posters?${searchParams.toString()}`,
-    { next: { revalidate: CACHE_1D, tags: [getHyperChatTag(channelId)] } }
+    { next: { revalidate: CACHE_1W, tags: [getHyperChatTag(channelId)] } }
   )
   if (!res.ok) {
     throw new Error(`Failed to fetch poster ranking: ${await res.text()}`)
@@ -33,7 +33,7 @@ export async function getPosterRankingCount(
 ): Promise<number> {
   const res = await fetchAPI(
     `/api/hyper-chat-rankings/channels/${channelId}/posters/count`,
-    { next: { revalidate: CACHE_1D, tags: [getHyperChatTag(channelId)] } }
+    { next: { revalidate: CACHE_1W, tags: [getHyperChatTag(channelId)] } }
   )
   if (!res.ok) {
     throw new Error(`Failed to fetch poster ranking count: ${await res.text()}`)
@@ -47,7 +47,7 @@ export async function getAnonymousPoster(
 ): Promise<AnonymousPosterSchema | null> {
   const res = await fetchAPI(
     `/api/hyper-chat-rankings/channels/${channelId}/anonymous`,
-    { next: { revalidate: CACHE_1D, tags: [getHyperChatTag(channelId)] } }
+    { next: { revalidate: CACHE_1W, tags: [getHyperChatTag(channelId)] } }
   )
   if (!res.ok) {
     throw new Error(`Failed to fetch anonymous poster: ${await res.text()}`)

--- a/web/apis/hyper-chats/getAllHyperChats.ts
+++ b/web/apis/hyper-chats/getAllHyperChats.ts
@@ -5,7 +5,7 @@ import {
   responseSchema
 } from 'apis/hyper-chats/hyperChatSchema'
 import { HYPER_CHATS_LATEST } from 'apis/tags/revalidate-tags'
-import { CACHE_1D, fetchAPI } from 'lib/fetchAPI'
+import { CACHE_1W, fetchAPI } from 'lib/fetchAPI'
 
 type Params = {
   userId?: number
@@ -39,7 +39,7 @@ export async function getAllHyperChats({
 
   const res = await fetchAPI(
     `/api/hyper-chats?${searchParams.toString()}`,
-    { next: { revalidate: CACHE_1D, tags: [HYPER_CHATS_LATEST] } }
+    { next: { revalidate: CACHE_1W, tags: [HYPER_CHATS_LATEST] } }
   )
   if (!res.ok) {
     throw new Error(`Failed to fetch all hyper chats: ${await res.text()}`)
@@ -50,7 +50,7 @@ export async function getAllHyperChats({
 
 export async function getAllHyperChatsCount(): Promise<number> {
   const res = await fetchAPI(`/api/hyper-chats/count`, {
-    next: { revalidate: CACHE_1D, tags: [HYPER_CHATS_LATEST] }
+    next: { revalidate: CACHE_1W, tags: [HYPER_CHATS_LATEST] }
   })
   if (!res.ok) {
     throw new Error(

--- a/web/apis/hyper-chats/getHyperChats.ts
+++ b/web/apis/hyper-chats/getHyperChats.ts
@@ -5,7 +5,7 @@ import {
   responseSchema
 } from 'apis/hyper-chats/hyperChatSchema'
 import { getHyperChatTag } from 'apis/tags/revalidate-tags'
-import { CACHE_1D, fetchAPI } from 'lib/fetchAPI'
+import { CACHE_1W, fetchAPI } from 'lib/fetchAPI'
 
 type Params = {
   channelId: string
@@ -51,7 +51,7 @@ export async function getHyperChats({
   const searchParams = createSearchParams(params)
   const res = await fetchAPI(
     `/api/hyper-chats/channels/${channelId}?${searchParams.toString()}`,
-    { next: { revalidate: CACHE_1D, tags: [getHyperChatTag(channelId)] } }
+    { next: { revalidate: CACHE_1W, tags: [getHyperChatTag(channelId)] } }
   )
   if (!res.ok) {
     throw new Error(`Failed to fetch hyper chats: ${await res.text()}`)
@@ -67,7 +67,7 @@ export async function getHyperChatsCount(
   const searchParams = createSearchParams(params ?? {})
   const res = await fetchAPI(
     `/api/hyper-chats/channels/${channelId}/count?${searchParams.toString()}`,
-    { next: { revalidate: CACHE_1D, tags: [getHyperChatTag(channelId)] } }
+    { next: { revalidate: CACHE_1W, tags: [getHyperChatTag(channelId)] } }
   )
   if (!res.ok) {
     throw new Error(`Failed to fetch hyper chats count: ${await res.text()}`)
@@ -83,7 +83,7 @@ export async function getHyperChatsSumAmount(
   const searchParams = createSearchParams(params ?? {})
   const res = await fetchAPI(
     `/api/hyper-chats/channels/${channelId}/sum-amount?${searchParams.toString()}`,
-    { next: { revalidate: CACHE_1D, tags: [getHyperChatTag(channelId)] } }
+    { next: { revalidate: CACHE_1W, tags: [getHyperChatTag(channelId)] } }
   )
   if (!res.ok) {
     throw new Error(
@@ -101,7 +101,7 @@ export async function getHyperChatsSumLikeCount(
   const searchParams = createSearchParams(params ?? {})
   const res = await fetchAPI(
     `/api/hyper-chats/channels/${channelId}/sum-like-count?${searchParams.toString()}`,
-    { next: { revalidate: CACHE_1D, tags: [getHyperChatTag(channelId)] } }
+    { next: { revalidate: CACHE_1W, tags: [getHyperChatTag(channelId)] } }
   )
   if (!res.ok) {
     throw new Error(

--- a/web/apis/hyper-chats/getLatestHyperChats.ts
+++ b/web/apis/hyper-chats/getLatestHyperChats.ts
@@ -3,14 +3,14 @@ import {
   responseSchema
 } from 'apis/hyper-chats/hyperChatSchema'
 import { HYPER_CHATS_LATEST } from 'apis/tags/revalidate-tags'
-import { CACHE_1D, fetchAPI } from 'lib/fetchAPI'
+import { CACHE_1W, fetchAPI } from 'lib/fetchAPI'
 
 /** Layout下部で使う専用のAPI */
 export async function getLatestHyperChats(
   limit = 20
 ): Promise<HyperChatsSchema> {
   const res = await fetchAPI(`/api/hyper-chats/latest?limit=${limit}`, {
-    next: { revalidate: CACHE_1D, tags: [HYPER_CHATS_LATEST] }
+    next: { revalidate: CACHE_1W, tags: [HYPER_CHATS_LATEST] }
   })
   if (!res.ok) {
     throw new Error(`Failed to fetch latest hyper chats: ${await res.text()}`)

--- a/web/apis/hyper-chats/getRecentHyperChats.ts
+++ b/web/apis/hyper-chats/getRecentHyperChats.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 import { schema, HyperChatSchema } from 'apis/hyper-chats/hyperChatSchema'
-import { fetchAPI } from 'lib/fetchAPI'
+import { CACHE_1H, fetchAPI } from 'lib/fetchAPI'
 
 // バックエンドはCollection形式（{ list: [...] }）で返却する
 const listSchema = z.object({ list: z.array(schema) })
@@ -24,10 +24,8 @@ export async function getRecentHyperChats(
     searchParams.append('channelIds[]', id)
   })
 
-  // TODO: cacheしてもよいが、ChannelIdごとにHyperChat更新された場合revalidateが難しい
   const res = await fetchAPI(`/api/hyper-chats/recent?${searchParams}`, {
-    // next: { revalidate: CACHE_10M }
-    cache: 'no-store'
+    next: { revalidate: CACHE_1H }
   })
 
   if (!res.ok) {

--- a/web/apis/hyper-trains/getHyperTrains.ts
+++ b/web/apis/hyper-trains/getHyperTrains.ts
@@ -6,7 +6,7 @@ import {
   hyperTrainsResponseSchema
 } from 'apis/hyper-trains/hyperTrainSchema'
 import { getHyperChatTag, HYPER_TRAINS_ACTIVE } from 'apis/tags/revalidate-tags'
-import { CACHE_1M, fetchAPI } from 'lib/fetchAPI'
+import { CACHE_10M, CACHE_1H, fetchAPI } from 'lib/fetchAPI'
 
 export async function getActiveHyperTrains(
   group?: string
@@ -14,7 +14,7 @@ export async function getActiveHyperTrains(
   const searchParams = new URLSearchParams(group ? { group } : {})
   const res = await fetchAPI(
     `/api/hyper-trains/active?${searchParams.toString()}`,
-    { next: { revalidate: CACHE_1M, tags: [HYPER_TRAINS_ACTIVE] } }
+    { next: { revalidate: CACHE_10M, tags: [HYPER_TRAINS_ACTIVE] } }
   )
   if (!res.ok) {
     throw new Error(
@@ -32,7 +32,7 @@ export async function getActiveHyperTrainByChannel(
   channelId: string
 ): Promise<HyperTrainSchema | null> {
   const res = await fetchAPI(`/api/hyper-trains/channels/${channelId}/active`, {
-    next: { revalidate: CACHE_1M, tags: [getHyperChatTag(channelId)] }
+    next: { revalidate: CACHE_10M, tags: [getHyperChatTag(channelId)] }
   })
   if (!res.ok) {
     throw new Error(
@@ -50,7 +50,7 @@ export async function getBestHyperTrain(
 ): Promise<HyperTrainSchema | null> {
   const res = await fetchAPI(
     `/api/hyper-trains/channels/${channelId}/best`,
-    { cache: 'no-store' } // 「終了」は自然発生するのでrevalidateが難しい。キャッシュ無効
+    { next: { revalidate: CACHE_1H } }
   )
   if (!res.ok) {
     throw new Error(
@@ -68,7 +68,7 @@ export async function getHyperTrainIncomingStatus(
 ): Promise<{ uniqueUserCount: number; cooldownEndsAt: string | null }> {
   const res = await fetchAPI(
     `/api/hyper-trains/channels/${channelId}/incoming`,
-    { next: { revalidate: CACHE_1M, tags: [getHyperChatTag(channelId)] } }
+    { next: { revalidate: CACHE_10M, tags: [getHyperChatTag(channelId)] } }
   )
   if (!res.ok) {
     throw new Error(

--- a/web/apis/inactive-channels/getInactiveChannels.ts
+++ b/web/apis/inactive-channels/getInactiveChannels.ts
@@ -1,4 +1,4 @@
-import { fetchAPI } from 'lib/fetchAPI'
+import { CACHE_1H, fetchAPI } from 'lib/fetchAPI'
 import {
   inactiveChannelsResponseSchema,
   InactiveChannelsSchema
@@ -9,7 +9,7 @@ export async function getInactiveChannels(
 ): Promise<InactiveChannelsSchema> {
   const res = await fetchAPI(
     `/api/inactive-channels?inactiveMonths=${inactiveMonths}`,
-    { cache: 'no-store' }
+    { next: { revalidate: CACHE_1H } }
   )
 
   if (!res.ok) {

--- a/web/apis/insights/getChannelGrowthRankings.ts
+++ b/web/apis/insights/getChannelGrowthRankings.ts
@@ -2,7 +2,7 @@ import {
   ChannelGrowthRankingsSchema,
   responseSchema
 } from 'apis/insights/schema/channelGrowthRankingSchema'
-import { CACHE_1H, fetchAPI } from 'lib/fetchAPI'
+import { CACHE_1D, fetchAPI } from 'lib/fetchAPI'
 
 type Params = {
   period?: 'weekly' | 'monthly'
@@ -43,7 +43,7 @@ export async function getChannelGrowthRankings({
   const res = await fetchAPI(
     `/api/insights/channel-growth-rankings?${params.toString()}`,
     {
-      next: { revalidate: CACHE_1H }
+      next: { revalidate: CACHE_1D }
     }
   )
 

--- a/web/apis/insights/getChannelSupersRankings.ts
+++ b/web/apis/insights/getChannelSupersRankings.ts
@@ -2,7 +2,7 @@ import {
   ChannelSupersRankingsSchema,
   responseSchema
 } from 'apis/insights/schema/channelSupersRankingSchema'
-import { CACHE_1H, fetchAPI } from 'lib/fetchAPI'
+import { CACHE_1D, fetchAPI } from 'lib/fetchAPI'
 
 type Params = {
   period: 'weekly' | 'monthly'
@@ -27,7 +27,7 @@ export async function getChannelSupersRankings({
   const res = await fetchAPI(
     `/api/insights/channel-supers-rankings?${params.toString()}`,
     {
-      next: { revalidate: CACHE_1H }
+      next: { revalidate: CACHE_1D }
     }
   )
 

--- a/web/apis/insights/getChannelViewCountRankings.ts
+++ b/web/apis/insights/getChannelViewCountRankings.ts
@@ -2,7 +2,7 @@ import {
   ChannelViewCountRankingsSchema,
   responseSchema
 } from 'apis/insights/schema/channelViewCountRankingSchema'
-import { CACHE_1H, fetchAPI } from 'lib/fetchAPI'
+import { CACHE_1D, fetchAPI } from 'lib/fetchAPI'
 
 type Params = {
   period?: 'weekly' | 'monthly'
@@ -33,7 +33,7 @@ export async function getChannelViewCountRankings({
   const res = await fetchAPI(
     `/api/insights/channel-view-count-rankings?${params.toString()}`,
     {
-      next: { revalidate: CACHE_1H }
+      next: { revalidate: CACHE_1D }
     }
   )
 

--- a/web/apis/insights/getConcurrentViewerTrend.ts
+++ b/web/apis/insights/getConcurrentViewerTrend.ts
@@ -2,7 +2,7 @@ import {
   ConcurrentViewerTrendsSchema,
   responseSchema
 } from 'apis/insights/schema/concurrentViewerTrendSchema'
-import { CACHE_1H, fetchAPI } from 'lib/fetchAPI'
+import { CACHE_1D, fetchAPI } from 'lib/fetchAPI'
 
 type Params = {
   days?: number
@@ -22,7 +22,7 @@ export async function getConcurrentViewerTrend({
   const res = await fetchAPI(
     `/api/insights/concurrent-viewer-trends?${params.toString()}`,
     {
-      next: { revalidate: CACHE_1H }
+      next: { revalidate: CACHE_1D }
     }
   )
 

--- a/web/apis/insights/getDayOfWeekDistribution.ts
+++ b/web/apis/insights/getDayOfWeekDistribution.ts
@@ -2,7 +2,7 @@ import {
   DayOfWeekDistributionsSchema,
   responseSchema
 } from 'apis/insights/schema/dayOfWeekDistributionSchema'
-import { CACHE_1H, fetchAPI } from 'lib/fetchAPI'
+import { CACHE_1D, fetchAPI } from 'lib/fetchAPI'
 
 type Params = {
   days?: number
@@ -22,7 +22,7 @@ export async function getDayOfWeekDistribution({
   const res = await fetchAPI(
     `/api/insights/day-of-week-distribution?${params.toString()}`,
     {
-      next: { revalidate: CACHE_1H }
+      next: { revalidate: CACHE_1D }
     }
   )
 

--- a/web/apis/insights/getGoldenTimes.ts
+++ b/web/apis/insights/getGoldenTimes.ts
@@ -2,7 +2,7 @@ import {
   GoldenTimesSchema,
   responseSchema
 } from 'apis/insights/schema/goldenTimeSchema'
-import { CACHE_1H, fetchAPI } from 'lib/fetchAPI'
+import { CACHE_1D, fetchAPI } from 'lib/fetchAPI'
 
 type Params = {
   days?: number
@@ -20,7 +20,7 @@ export async function getGoldenTimes({
   }
 
   const res = await fetchAPI(`/api/insights/golden-times?${params.toString()}`, {
-    next: { revalidate: CACHE_1H }
+    next: { revalidate: CACHE_1D }
   })
 
   if (!res.ok) {

--- a/web/apis/insights/getStreamVolumeTrend.ts
+++ b/web/apis/insights/getStreamVolumeTrend.ts
@@ -2,7 +2,7 @@ import {
   StreamVolumeTrendsSchema,
   responseSchema
 } from 'apis/insights/schema/streamVolumeTrendSchema'
-import { CACHE_1H, fetchAPI } from 'lib/fetchAPI'
+import { CACHE_1D, fetchAPI } from 'lib/fetchAPI'
 
 type Params = {
   days?: number
@@ -22,7 +22,7 @@ export async function getStreamVolumeTrend({
   const res = await fetchAPI(
     `/api/insights/stream-volume-trends?${params.toString()}`,
     {
-      next: { revalidate: CACHE_1H }
+      next: { revalidate: CACHE_1D }
     }
   )
 

--- a/web/apis/supers/getSupersBundle.ts
+++ b/web/apis/supers/getSupersBundle.ts
@@ -2,13 +2,13 @@ import {
   SupersBundleSchema,
   schema
 } from 'apis/youtube/schema/supersBundleSchema'
-import { CACHE_1H, fetchAPI } from 'lib/fetchAPI'
+import { CACHE_1D, fetchAPI } from 'lib/fetchAPI'
 
 export async function getSupersBundle(
   videoId: string
 ): Promise<SupersBundleSchema | undefined> {
   const res = await fetchAPI(`/api/supers-bundles/${videoId}`, {
-    next: { revalidate: CACHE_1H }
+    next: { revalidate: CACHE_1D }
   })
   if (!res.ok) {
     throw new Error(`Failed to fetch data: ${await res.text()}`)

--- a/web/apis/supers/getSupersBundleRank.ts
+++ b/web/apis/supers/getSupersBundleRank.ts
@@ -3,7 +3,7 @@ import {
   SupersBundleRankSchema,
   schema
 } from 'apis/youtube/schema/supersBundleRankSchema'
-import { CACHE_1D, fetchAPI } from 'lib/fetchAPI'
+import { CACHE_1W, fetchAPI } from 'lib/fetchAPI'
 import { RankingType } from 'types/ranking'
 
 type Params = {
@@ -17,7 +17,7 @@ export async function getSupersBundleRank({
 }: Params): Promise<SupersBundleRankSchema | undefined> {
   const res = await fetchAPI(
     `/api/supers-bundles/${videoId}/rank?rankingType=${rankingType}`,
-    { next: { revalidate: CACHE_1D, tags: [SUPERS_BUNDLES] } }
+    { next: { revalidate: CACHE_1W, tags: [SUPERS_BUNDLES] } }
   )
   if (!res.ok) {
     throw new Error(`Failed to fetch data: ${await res.text()}`)

--- a/web/apis/supers/getSupersBundleSum.ts
+++ b/web/apis/supers/getSupersBundleSum.ts
@@ -2,7 +2,7 @@ import {
   sumSchema,
   SupersBundleSumSchema
 } from 'apis/youtube/schema/supersBundleSchema'
-import { CACHE_1H, fetchAPI } from 'lib/fetchAPI'
+import { CACHE_1D, fetchAPI } from 'lib/fetchAPI'
 
 type Params = {
   channelId: string
@@ -23,7 +23,7 @@ export async function getSupersBundleSum({
   })
   const res = await fetchAPI(
     `/api/supers-bundles/sum?${searchParams.toString()}`,
-    { next: { revalidate: CACHE_1H } }
+    { next: { revalidate: CACHE_1D } }
   )
 
   if (!res.ok) {

--- a/web/apis/supers/getSupersBundles.ts
+++ b/web/apis/supers/getSupersBundles.ts
@@ -3,7 +3,7 @@ import {
   listSchema
 } from 'apis/youtube/schema/supersBundleSchema'
 
-import { CACHE_1D, CACHE_1H, fetchAPI } from 'lib/fetchAPI'
+import { CACHE_1D, CACHE_1W, fetchAPI } from 'lib/fetchAPI'
 import { Gender } from 'types/gender'
 import { roundDateToDay, roundDateToHour } from 'utils/date'
 
@@ -99,7 +99,7 @@ export async function getSupersBundles({
     createdAtLTE: roundDateToHour(createdAtLTE)
   })
   const res = await fetchAPI(`/api/supers-bundles?${searchParams.toString()}`, {
-    next: { revalidate: CACHE_1H }
+    next: { revalidate: CACHE_1D }
   })
   if (!res.ok) {
     throw new Error(`Failed to fetch data: ${await res.text()}`)
@@ -153,7 +153,7 @@ export async function getSupersBundlesCount({
   })
   const res = await fetchAPI(
     `/api/supers-bundles/count?${searchParams.toString()}`,
-    { next: { revalidate: CACHE_1D } }
+    { next: { revalidate: CACHE_1W } }
   )
   if (!res.ok) {
     throw new Error(`Failed to fetch data: ${await res.text()}`)

--- a/web/apis/supers/getSupersMonthlySummaries.ts
+++ b/web/apis/supers/getSupersMonthlySummaries.ts
@@ -3,7 +3,7 @@ import {
   listSchema,
   SupersMonthlySummariesSchema
 } from 'apis/youtube/schema/supersMonthlySummarySchema'
-import { CACHE_1D, fetchAPI } from 'lib/fetchAPI'
+import { CACHE_1W, fetchAPI } from 'lib/fetchAPI'
 
 type Params = {
   channelId: string
@@ -24,7 +24,7 @@ export async function getSupersMonthlySummaries({
 
   const res = await fetchAPI(
     `/api/supers-summaries/monthly?${searchParams.toString()}`,
-    { next: { revalidate: CACHE_1D, tags: [SUPERS_SUMMARIES] } }
+    { next: { revalidate: CACHE_1W, tags: [SUPERS_SUMMARIES] } }
   )
 
   if (!res.ok) {

--- a/web/apis/supers/getSupersRankingHistories.ts
+++ b/web/apis/supers/getSupersRankingHistories.ts
@@ -6,7 +6,7 @@ import {
   SupersRankingHistoriesSchema,
   responseHistoriesSchema
 } from 'apis/youtube/schema/supersRankingSchema'
-import { CACHE_1H, CACHE_1D, fetchAPI } from 'lib/fetchAPI'
+import { CACHE_1D, CACHE_1W, fetchAPI } from 'lib/fetchAPI'
 import { Period } from 'types/period'
 import { RankingType } from 'types/ranking'
 
@@ -44,8 +44,8 @@ export async function getSupersRankingHistories({
   // キャッシュしているが消してもいいかもしれない
   const cache: RequestInit =
     period === 'last24Hours'
-      ? { next: { revalidate: CACHE_1H, tags: [SUPERS_RANKINGS_HALF_HOURLY] } }
-      : { next: { revalidate: CACHE_1D, tags: [SUPERS_RANKINGS] } }
+      ? { next: { revalidate: CACHE_1D, tags: [SUPERS_RANKINGS_HALF_HOURLY] } }
+      : { next: { revalidate: CACHE_1W, tags: [SUPERS_RANKINGS] } }
 
   const res = await fetchAPI(
     `/api/supers-rankings/histories?${searchParams.toString()}`,

--- a/web/apis/supers/getSupersRankings.ts
+++ b/web/apis/supers/getSupersRankings.ts
@@ -6,7 +6,7 @@ import {
   responseSchema,
   SupersRankingSchema
 } from 'apis/youtube/schema/supersRankingSchema'
-import { CACHE_1H, CACHE_1D, fetchAPI } from 'lib/fetchAPI'
+import { CACHE_1D, CACHE_1W, fetchAPI } from 'lib/fetchAPI'
 import { Period } from 'types/period'
 import { RankingType } from 'types/ranking'
 
@@ -31,8 +31,8 @@ export async function getSupersRankings({
   // キャッシュしているが消してもいいかもしれない
   const cache: RequestInit =
     period === 'last24Hours'
-      ? { next: { revalidate: CACHE_1H, tags: [SUPERS_RANKINGS_HALF_HOURLY] } }
-      : { next: { revalidate: CACHE_1D, tags: [SUPERS_RANKINGS] } }
+      ? { next: { revalidate: CACHE_1D, tags: [SUPERS_RANKINGS_HALF_HOURLY] } }
+      : { next: { revalidate: CACHE_1W, tags: [SUPERS_RANKINGS] } }
 
   const res = await fetchAPI(
     `/api/supers-rankings?${searchParams.toString()}`,

--- a/web/apis/supers/getSupersSummaries.ts
+++ b/web/apis/supers/getSupersSummaries.ts
@@ -7,7 +7,7 @@ import {
   responseListSchema
 } from 'apis/youtube/schema/supersSummarySchema'
 
-import { CACHE_1H, CACHE_1D, fetchAPI } from 'lib/fetchAPI'
+import { CACHE_1D, CACHE_1W, fetchAPI } from 'lib/fetchAPI'
 import { Gender } from 'types/gender'
 import { Period } from 'types/period'
 
@@ -70,8 +70,8 @@ export async function getSupersSummaries(
   const cacheOption = params.orderBy?.some(
     orderBy => orderBy.field === 'last24Hours'
   )
-    ? { next: { revalidate: CACHE_1H, tags: [SUPERS_SUMMARIES_HALF_HOURLY] } }
-    : { next: { revalidate: CACHE_1D, tags: [SUPERS_SUMMARIES] } }
+    ? { next: { revalidate: CACHE_1D, tags: [SUPERS_SUMMARIES_HALF_HOURLY] } }
+    : { next: { revalidate: CACHE_1W, tags: [SUPERS_SUMMARIES] } }
 
   const res = await fetchAPI(
     `/api/supers-summaries?${searchParams.toString()}`,
@@ -112,8 +112,8 @@ export async function getSupersSummariesCount({
     orderBy
   })
   const cacheOption = orderBy?.some(o => o.field === 'last24Hours')
-    ? { next: { revalidate: CACHE_1H, tags: [SUPERS_SUMMARIES_HALF_HOURLY] } }
-    : { next: { revalidate: CACHE_1D, tags: [SUPERS_SUMMARIES] } }
+    ? { next: { revalidate: CACHE_1D, tags: [SUPERS_SUMMARIES_HALF_HOURLY] } }
+    : { next: { revalidate: CACHE_1W, tags: [SUPERS_SUMMARIES] } }
 
   const res = await fetchAPI(
     `/api/supers-summaries/count?${searchParams.toString()}`,

--- a/web/apis/supers/getSupersSummary.ts
+++ b/web/apis/supers/getSupersSummary.ts
@@ -3,13 +3,13 @@ import {
   responseSchema,
   SupersSummarySchema
 } from 'apis/youtube/schema/supersSummarySchema'
-import { CACHE_1D, fetchAPI } from 'lib/fetchAPI'
+import { CACHE_1W, fetchAPI } from 'lib/fetchAPI'
 
 export async function getSupersSummary(
   channelId: string
 ): Promise<SupersSummarySchema> {
   const res = await fetchAPI(`/api/supers-summaries/${channelId}`, {
-    next: { revalidate: CACHE_1D, tags: [SUPERS_SUMMARIES] }
+    next: { revalidate: CACHE_1W, tags: [SUPERS_SUMMARIES] }
   })
   if (!res.ok) {
     throw new Error('Failed to fetch data')

--- a/web/apis/user-profiles/getUserProfiles.ts
+++ b/web/apis/user-profiles/getUserProfiles.ts
@@ -1,4 +1,4 @@
-import { CACHE_1H, fetchAPI } from 'lib/fetchAPI'
+import { CACHE_1D, fetchAPI } from 'lib/fetchAPI'
 import { responseListSchema, UserProfilesSchema } from './userProfileSchema'
 
 type Params = {
@@ -42,7 +42,7 @@ export async function getUserProfilesCount(
   const searchParams = createSearchParams(params)
   const res = await fetchAPI(
     `/api/user-profiles/count?${searchParams.toString()}`,
-    { next: { revalidate: CACHE_1H } }
+    { next: { revalidate: CACHE_1D } }
   )
   if (!res.ok) {
     throw new Error(`Failed to fetch data: ${await res.text()}`)

--- a/web/apis/youtube/data-api/getCommentThreads.ts
+++ b/web/apis/youtube/data-api/getCommentThreads.ts
@@ -3,7 +3,7 @@ import {
   CommentThreadsListSchema,
   responseSchema
 } from 'apis/youtube/data-api/schema/commentThreadsSchema'
-import { CACHE_12H } from 'lib/fetchAPI'
+import { CACHE_1D } from 'lib/fetchAPI'
 
 const MaxResultsPerRequest = 100
 
@@ -44,7 +44,7 @@ export async function getCommentThreads({
   })
   const res = await fetch(
     `https://www.googleapis.com/youtube/v3/commentThreads?${searchParams.toString()}`,
-    { next: { revalidate: CACHE_12H } }
+    { next: { revalidate: CACHE_1D } }
   )
   if (!res.ok) {
     if (res.status === 403 || res.status === 404) {

--- a/web/apis/youtube/getChannel.ts
+++ b/web/apis/youtube/getChannel.ts
@@ -2,11 +2,11 @@
 
 import { notFound } from 'next/navigation'
 import { ChannelSchema, schema } from 'apis/youtube/schema/channelSchema'
-import { CACHE_1D, fetchAPI } from 'lib/fetchAPI'
+import { CACHE_1W, fetchAPI } from 'lib/fetchAPI'
 
 export async function getChannel(id: string): Promise<ChannelSchema> {
   const res = await fetchAPI(`/api/youtube/channels/${id}`, {
-    next: { revalidate: CACHE_1D }
+    next: { revalidate: CACHE_1W }
   })
 
   if (!res.ok) {
@@ -26,7 +26,7 @@ export async function getChannel(id: string): Promise<ChannelSchema> {
 /** 指定したチャンネルIDのチャンネルが存在するかどうかを判定 */
 export async function existsChannel(id: string): Promise<boolean> {
   const res = await fetchAPI(`/api/youtube/channels/${id}`, {
-    next: { revalidate: CACHE_1D }
+    next: { revalidate: CACHE_1W }
   })
   if (!res.ok) {
     if (res.status === 404) {

--- a/web/apis/youtube/getChannelRegistration.ts
+++ b/web/apis/youtube/getChannelRegistration.ts
@@ -4,13 +4,13 @@ import {
   ChannelRegistrationSchema,
   schema
 } from 'apis/youtube/schema/channelRegistrationSchema'
-import { fetchAPI } from 'lib/fetchAPI'
+import { CACHE_1H, fetchAPI } from 'lib/fetchAPI'
 
 export async function getChannelRegistration(
   id: string
 ): Promise<ChannelRegistrationSchema | undefined> {
   const res = await fetchAPI(`/api/channel-registrations/${id}`, {
-    cache: 'no-store'
+    next: { revalidate: CACHE_1H }
   })
 
   if (!res.ok) {

--- a/web/apis/youtube/getChannelRegistrations.ts
+++ b/web/apis/youtube/getChannelRegistrations.ts
@@ -4,7 +4,7 @@ import {
   ChannelRegistrationSchema,
   listSchema
 } from 'apis/youtube/schema/channelRegistrationSchema'
-import { fetchAPI } from 'lib/fetchAPI'
+import { CACHE_1H, fetchAPI } from 'lib/fetchAPI'
 
 type Params = {
   status?: string
@@ -36,7 +36,7 @@ export async function getChannelRegistrations({
   }
   const res = await fetchAPI(
     `/api/channel-registrations?${searchParams.toString()}`,
-    { cache: 'no-store' }
+    { next: { revalidate: CACHE_1H } }
   )
 
   if (!res.ok) {

--- a/web/apis/youtube/getChannels.ts
+++ b/web/apis/youtube/getChannels.ts
@@ -3,7 +3,7 @@ import {
   responseSchema
 } from 'apis/youtube/schema/channelSchema'
 
-import { CACHE_1D, fetchAPI } from 'lib/fetchAPI'
+import { CACHE_1W, fetchAPI } from 'lib/fetchAPI'
 import { Gender } from 'types/gender'
 
 type Params = {
@@ -44,7 +44,7 @@ export async function getChannels({
 
   const res = await fetchAPI(
     `/api/youtube/channels?${searchParams.toString()}`,
-    { next: { revalidate: CACHE_1D } }
+    { next: { revalidate: CACHE_1W } }
   )
 
   if (!res.ok) {
@@ -65,7 +65,7 @@ export async function getChannelsCount({
   })
   const res = await fetchAPI(
     `/api/youtube/channels/count?${searchParams.toString()}`,
-    { next: { revalidate: CACHE_1D } }
+    { next: { revalidate: CACHE_1W } }
   )
   if (!res.ok) {
     throw new Error(`Failed to fetch data: ${await res.text()}`)

--- a/web/apis/youtube/getChannelsVideoCountSum.ts
+++ b/web/apis/youtube/getChannelsVideoCountSum.ts
@@ -1,8 +1,8 @@
-import { CACHE_1D, fetchAPI } from 'lib/fetchAPI'
+import { CACHE_1W, fetchAPI } from 'lib/fetchAPI'
 
 export async function getChannelsVideoCountSum(): Promise<number> {
   const res = await fetchAPI('/api/youtube/channels/video-count-sum', {
-    next: { revalidate: CACHE_1D }
+    next: { revalidate: CACHE_1W }
   })
   if (!res.ok) {
     throw new Error(`Failed to fetch data: ${await res.text()}`)

--- a/web/apis/youtube/getExchangeRates.ts
+++ b/web/apis/youtube/getExchangeRates.ts
@@ -2,11 +2,11 @@ import {
   ExchangeRatesSchema,
   responseSchema
 } from 'apis/youtube/schema/exchangeRateSchema'
-import { CACHE_1D, fetchAPI } from 'lib/fetchAPI'
+import { CACHE_1W, fetchAPI } from 'lib/fetchAPI'
 
 export async function getExchangeRates(): Promise<ExchangeRatesSchema> {
   const res = await fetchAPI(`/api/exchange-rates`, {
-    next: { revalidate: CACHE_1D }
+    next: { revalidate: CACHE_1W }
   })
   if (!res.ok) {
     throw new Error('Failed to fetch data')

--- a/web/apis/youtube/getMembershipBundle.ts
+++ b/web/apis/youtube/getMembershipBundle.ts
@@ -2,13 +2,13 @@ import {
   MembershipBundleSchema,
   schema
 } from 'apis/youtube/schema/membershipBundleSchema'
-import { CACHE_1D, fetchAPI } from 'lib/fetchAPI'
+import { CACHE_1W, fetchAPI } from 'lib/fetchAPI'
 
 export async function getMembershipBundle(
   videoId: string
 ): Promise<MembershipBundleSchema | undefined> {
   const res = await fetchAPI(`/api/membership-bundles/${videoId}`, {
-    next: { revalidate: CACHE_1D }
+    next: { revalidate: CACHE_1W }
   })
   if (!res.ok) {
     throw new Error(`Failed to fetch data: ${await res.text()}`)

--- a/web/apis/youtube/getStream.ts
+++ b/web/apis/youtube/getStream.ts
@@ -1,6 +1,6 @@
 import { notFound } from 'next/navigation'
 import { responseSchema, StreamSchema } from 'apis/youtube/schema/streamSchema'
-import { CACHE_1H, fetchAPI } from 'lib/fetchAPI'
+import { CACHE_1D, fetchAPI } from 'lib/fetchAPI'
 
 // Custom error class for 404 Not Found errors
 export class NotFoundError extends Error {
@@ -12,7 +12,7 @@ export class NotFoundError extends Error {
 
 export async function getStream(id: string): Promise<StreamSchema> {
   const res = await fetchAPI(`/api/youtube/streams/${id}`, {
-    next: { revalidate: CACHE_1H }
+    next: { revalidate: CACHE_1D }
   })
 
   if (!res.ok) {

--- a/web/apis/youtube/getStreams.ts
+++ b/web/apis/youtube/getStreams.ts
@@ -3,7 +3,7 @@ import {
   responseListSchema
 } from 'apis/youtube/schema/streamSchema'
 
-import { CACHE_10M, CACHE_1D, CACHE_1H, fetchAPI } from 'lib/fetchAPI'
+import { CACHE_1H, CACHE_1D, CACHE_1W, fetchAPI } from 'lib/fetchAPI'
 import { Gender } from 'types/gender'
 import { roundDateTo10Minutes, roundDateToHour } from 'utils/date'
 
@@ -123,7 +123,7 @@ export async function getStreams({
     endedAfter: roundDateTo10Minutes(endedAfter)
   })
   // ended は変更されにくいため長めにキャッシュ
-  const revalidate = params.status === 'ended' ? CACHE_1D : CACHE_10M
+  const revalidate = params.status === 'ended' ? CACHE_1W : CACHE_1H
   const res = await fetchAPI(
     `/api/youtube/streams?${searchParams.toString()}`,
     { next: { revalidate } }
@@ -189,7 +189,7 @@ export async function getStreamsCount({
   })
   const res = await fetchAPI(
     `/api/youtube/streams/count?${searchParams.toString()}`,
-    { next: { revalidate: CACHE_1H } }
+    { next: { revalidate: CACHE_1D } }
   )
   if (!res.ok) {
     throw new Error(`Failed to fetch data: ${await res.text()}`)

--- a/web/apis/youtube/getViewerCounts.ts
+++ b/web/apis/youtube/getViewerCounts.ts
@@ -2,7 +2,7 @@ import {
   ViewerCountsSchema,
   responseSchema
 } from 'apis/youtube/schema/viewerCountSchema'
-import { CACHE_1H, fetchAPI } from 'lib/fetchAPI'
+import { CACHE_1D, fetchAPI } from 'lib/fetchAPI'
 
 type Params = {
   videoId: string
@@ -13,7 +13,7 @@ export async function getViewerCounts({
 }: Params): Promise<ViewerCountsSchema> {
   const res = await fetchAPI(
     `/api/youtube/stream-stats/viewer-counts?videoId=${videoId}`,
-    { next: { revalidate: CACHE_1H } }
+    { next: { revalidate: CACHE_1D } }
   )
 
   if (!res.ok) {

--- a/web/lib/fetchAPI.ts
+++ b/web/lib/fetchAPI.ts
@@ -24,7 +24,7 @@ export const fetchAPI = async (
     if (!init) init = {}
     if (!init.next) init.next = {}
     if (init.next.revalidate === undefined) {
-      init.next.revalidate = CACHE_1M
+      init.next.revalidate = CACHE_10M
     }
   }
 


### PR DESCRIPTION
## Summary

- 全40ファイルのrevalidate期間を一段階引き上げ、Vercelデータキャッシュのヒット率を大幅向上
- UXより配信コスト削減を優先する方針で変更

## 変更マッピング

| 変更前 | 変更後 | 主な対象 |
|--------|--------|---------|
| デフォルト 1分 | **10分** | `fetchAPI.ts`（明示指定なしの全API） |
| 1分 | **10分** | ハイパートレイン Active/Incoming |
| `no-store` | **1時間** | getBestHyperTrain, getRecentHyperChats, getChannelRegistrations, getGroupRegistrations, getInactiveChannels |
| 10分 | **1時間** | getStreams（ライブ中）, getStreamsCount |
| 1時間 | **1日** | Insights API ×7, Supers last24h系, getStream, getViewerCounts, getUserProfilesCount |
| 12時間 | **1日** | getCommentThreads（YouTube Data API） |
| 1日 | **1週間** | Groups, Channels, HyperChats, Supers通常期間, getExchangeRates, getMembershipBundle 等 |

## Test plan

- [ ] 型チェック通過済み（`npm run type-check`）
- [ ] Lint通過済み（`npm run lint`）
- [ ] デプロイ後、Vercel Analytics でキャッシュHIT率の改善を確認
- [ ] Vercelの月額請求が$40以下に下がることを翌月請求で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)